### PR TITLE
feat: add SSH-to-HTTP transparent WAN tunnel benchmark

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -26,7 +26,7 @@ linters:
       # Fire-and-forget server goroutines in cmd/ entrypoints
       - linters:
           - errcheck
-        source: "go .+\\.(ListenAndServe|ListenAndServeTLS)\\(\\)"
+        source: "go .+\\.(ListenAndServe|ListenAndServeTLS|ListenAndServeH3)\\(\\)"
     paths:
       - third_party$
       - builtin$

--- a/README.md
+++ b/README.md
@@ -22,6 +22,9 @@ emulates a Cisco IOS-XE device over:
   endpoints, including 0-RTT session resumption support
 - **Proxy** (port 9443) — HTTPS frontend that forwards to an SSH backend,
   simulating the edge proxy pattern
+- **Tunnel** (headend + site proxy pair) — SSH-to-HTTP transparent WAN
+  tunnel where both automation and device speak SSH, but the WAN segment
+  uses HTTPS or HTTP/3 for fewer round trips
 
 All transports share the same command engine and transcript responses, so
 the only variable is the transport protocol itself.
@@ -85,6 +88,10 @@ Output is JSON to stdout. Logs go to stderr.
 | `keep-alive` | HTTP/3 | Shared QUIC connection across all iterations |
 | `batch-post` | HTTP/3 | All commands in one POST body over shared connection |
 | `0rtt-resumption` | HTTP/3 | QUIC 0-RTT session resumption (send data in first packet) |
+| `ssh-https-ssh` | Tunnel | SSH→headend→HTTPS(WAN)→site→SSH→device |
+| `ssh-https-ssh-batch` | Tunnel | Same with all commands in one SSH exec payload |
+| `ssh-h3-ssh` | Tunnel | SSH→headend→HTTP/3(WAN)→site→SSH→device |
+| `ssh-h3-ssh-batch` | Tunnel | Same with all commands in one SSH exec payload |
 
 ## Latency Profiles
 
@@ -189,7 +196,8 @@ internal/
   sshserver/  # crypto/ssh server
   httpserver/ # net/http + TLS server (ASA-style API)
   http3server/ # HTTP/3 (QUIC) server (same ASA-style API over QUIC)
-  latency/    # Userspace delay injection (fallback, -userspace flag)
+  headend/    # SSH→HTTP headend proxy (tunnel automation side)
+  latency/    # Userspace delay injection (fallback, --userspace flag)
   netem/      # tc netem setup via netlink (default, requires root)
   proxy/      # HTTPS→SSH edge proxy (fresh + pooled modes)
   stats/      # Benchmark statistics (percentile, summarize, runParallel)

--- a/cmd/clibench/bench.go
+++ b/cmd/clibench/bench.go
@@ -73,10 +73,12 @@ func (b *BenchCmd) Run() error {
 	headendH3Addr := fmt.Sprintf("localhost:%d", b.HeadendH3Port)
 	tunnelSiteHTTPSPort := b.ProxyPort + 2
 	tunnelSiteHTTPSAddr := fmt.Sprintf("localhost:%d", tunnelSiteHTTPSPort)
+	tunnelSiteH3Port := b.ProxyPort + 3
+	tunnelSiteH3Addr := fmt.Sprintf("localhost:%d", tunnelSiteH3Port)
 	campusDelay := 1 * time.Millisecond
 
 	if !b.Userspace && delay > 0 {
-		wanPorts := []int{b.SSHPort, b.HTTPSPort, b.HTTP3Port, b.ProxyPort, b.ProxyPort + 1, tunnelSiteHTTPSPort}
+		wanPorts := []int{b.SSHPort, b.HTTPSPort, b.HTTP3Port, b.ProxyPort, b.ProxyPort + 1, tunnelSiteHTTPSPort, tunnelSiteH3Port}
 		campusPorts := []int{backendSSHPort, b.HeadendHTTPSPort, b.HeadendH3Port}
 		if err := netem.Setup(delay, campusDelay, wanPorts, campusPorts); err != nil {
 			return fmt.Errorf("tc netem setup (requires sudo): %w", err)
@@ -149,6 +151,10 @@ func (b *BenchCmd) Run() error {
 	// Tunnel: site proxy (HTTPS frontend, WAN delay) → backend SSH (campus delay)
 	startProxy(tunnelSiteHTTPSAddr, backendSSHAddr, true, delay)
 
+	// Tunnel: site proxy HTTP/3 (WAN delay) → backend SSH (campus delay)
+	tunnelSiteH3 := proxy.New(tunnelSiteH3Addr, backendSSHAddr, b.User, b.Pass, true)
+	go tunnelSiteH3.ListenAndServeH3()
+
 	// Tunnel: headend proxies (SSH frontend, campus delay) → site proxy over WAN
 	startHeadend := func(addr, backendURL, transport string, d time.Duration) {
 		ln, err := net.Listen("tcp", addr)
@@ -163,7 +169,7 @@ func (b *BenchCmd) Run() error {
 		go srv.ListenAndServe()
 	}
 	startHeadend(headendHTTPSAddr, fmt.Sprintf("https://%s", tunnelSiteHTTPSAddr), "https", campusDelay)
-	startHeadend(headendH3Addr, fmt.Sprintf("https://%s", tunnelSiteHTTPSAddr), "http3", campusDelay)
+	startHeadend(headendH3Addr, fmt.Sprintf("https://%s", tunnelSiteH3Addr), "http3", campusDelay)
 
 	time.Sleep(500 * time.Millisecond)
 	log.Printf("Server ready — profile=%s, simulated RTT=%.0fms", b.Latency, rttMs)

--- a/cmd/clibench/bench.go
+++ b/cmd/clibench/bench.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/lykinsbd/clibench/internal/bench"
 	"github.com/lykinsbd/clibench/internal/device"
+	"github.com/lykinsbd/clibench/internal/headend"
 	"github.com/lykinsbd/clibench/internal/http3server"
 	"github.com/lykinsbd/clibench/internal/httpserver"
 	latencyPkg "github.com/lykinsbd/clibench/internal/latency"
@@ -23,7 +24,7 @@ import (
 
 // BenchCmd runs transport benchmarks.
 type BenchCmd struct {
-	Transport   string `help:"Transport to benchmark (${enum})." enum:"ssh,https,http3,proxy,all" default:"all" short:"t"`
+	Transport   string `help:"Transport to benchmark (${enum})." enum:"ssh,https,http3,proxy,tunnel,all" default:"all" short:"t"`
 	Iterations  int    `help:"Iterations per benchmark mode." default:"50" short:"n"`
 	Concurrency int    `help:"Concurrent workers." default:"1" short:"c"`
 	Commands    int    `help:"Commands per iteration." default:"1"`
@@ -31,10 +32,14 @@ type BenchCmd struct {
 	Userspace   bool   `help:"Use userspace latency injection (no root required)."`
 	Output      string `help:"Output format (${enum})." enum:"json,table,csv" default:"json" short:"o"`
 
-	SSHPort   int `help:"SSH listen port." default:"2222" group:"server"`
-	HTTPSPort int `help:"HTTPS listen port." default:"8443" group:"server"`
-	HTTP3Port int `help:"HTTP/3 listen port." default:"8444" group:"server"`
-	ProxyPort int `help:"Proxy listen port." default:"9443" group:"server"`
+	SSHPort              int `help:"SSH listen port." default:"2222" group:"server"`
+	HTTPSPort            int `help:"HTTPS listen port." default:"8443" group:"server"`
+	HTTP3Port            int `help:"HTTP/3 listen port." default:"8444" group:"server"`
+	ProxyPort            int `help:"Proxy listen port." default:"9443" group:"server"`
+	HeadendHTTPSPort     int `help:"Headend proxy SSH port (HTTPS WAN)." default:"2223" group:"server"`
+	HeadendH3Port        int `help:"Headend proxy SSH port (HTTP/3 WAN)." default:"2224" group:"server"`
+	TunnelEdgeHTTPSPort int `help:"Tunnel edge proxy SSH port (HTTPS WAN)." default:"2223" group:"server"`
+	TunnelEdgeH3Port    int `help:"Tunnel edge proxy SSH port (HTTP/3 WAN)." default:"2224" group:"server"`
 
 	User        string `help:"Username." default:"admin" short:"u"`
 	Pass        string `help:"Password." default:"admin" short:"p"`
@@ -64,11 +69,15 @@ func (b *BenchCmd) Run() error {
 	backendSSHAddr := fmt.Sprintf("localhost:%d", backendSSHPort)
 	proxyAddr := fmt.Sprintf("localhost:%d", b.ProxyPort)
 	proxyPooledAddr := fmt.Sprintf("localhost:%d", b.ProxyPort+1)
+	headendHTTPSAddr := fmt.Sprintf("localhost:%d", b.HeadendHTTPSPort)
+	headendH3Addr := fmt.Sprintf("localhost:%d", b.HeadendH3Port)
+	tunnelSiteHTTPSPort := b.ProxyPort + 2
+	tunnelSiteHTTPSAddr := fmt.Sprintf("localhost:%d", tunnelSiteHTTPSPort)
 	campusDelay := 1 * time.Millisecond
 
 	if !b.Userspace && delay > 0 {
-		wanPorts := []int{b.SSHPort, b.HTTPSPort, b.HTTP3Port, b.ProxyPort, b.ProxyPort + 1}
-		campusPorts := []int{backendSSHPort}
+		wanPorts := []int{b.SSHPort, b.HTTPSPort, b.HTTP3Port, b.ProxyPort, b.ProxyPort + 1, tunnelSiteHTTPSPort}
+		campusPorts := []int{backendSSHPort, b.HeadendHTTPSPort, b.HeadendH3Port}
 		if err := netem.Setup(delay, campusDelay, wanPorts, campusPorts); err != nil {
 			return fmt.Errorf("tc netem setup (requires sudo): %w", err)
 		}
@@ -137,6 +146,25 @@ func (b *BenchCmd) Run() error {
 	h3srv := http3server.New(http3Addr, dev)
 	go h3srv.ListenAndServe()
 
+	// Tunnel: site proxy (HTTPS frontend, WAN delay) → backend SSH (campus delay)
+	startProxy(tunnelSiteHTTPSAddr, backendSSHAddr, true, delay)
+
+	// Tunnel: headend proxies (SSH frontend, campus delay) → site proxy over WAN
+	startHeadend := func(addr, backendURL, transport string, d time.Duration) {
+		ln, err := net.Listen("tcp", addr)
+		if err != nil {
+			log.Fatalf("listen %s: %v", addr, err)
+		}
+		srv, err := headend.New(addr, backendURL, b.User, b.Pass, transport)
+		if err != nil {
+			log.Fatalf("headend %s: %v", addr, err)
+		}
+		srv.SetListener(wrapListener(ln, d))
+		go srv.ListenAndServe()
+	}
+	startHeadend(headendHTTPSAddr, fmt.Sprintf("https://%s", tunnelSiteHTTPSAddr), "https", campusDelay)
+	startHeadend(headendH3Addr, fmt.Sprintf("https://%s", tunnelSiteHTTPSAddr), "http3", campusDelay)
+
 	time.Sleep(500 * time.Millisecond)
 	log.Printf("Server ready — profile=%s, simulated RTT=%.0fms", b.Latency, rttMs)
 
@@ -174,6 +202,13 @@ func (b *BenchCmd) Run() error {
 		c := cfg
 		c.Addr = http3Addr
 		results = append(results, bench.HTTP3(c)...)
+	}
+	if b.Transport == "tunnel" || b.Transport == "all" {
+		results = append(results, bench.Tunnel(bench.TunnelConfig{
+			Config:           cfg,
+			HTTPSHeadendAddr: headendHTTPSAddr,
+			H3HeadendAddr:    headendH3Addr,
+		})...)
 	}
 
 	return outputResults(results, b.Output)

--- a/internal/bench/tunnel.go
+++ b/internal/bench/tunnel.go
@@ -1,0 +1,93 @@
+package bench
+
+import (
+	"log"
+	"time"
+
+	"github.com/lykinsbd/clibench/internal/stats"
+	"golang.org/x/crypto/ssh"
+)
+
+// TunnelConfig extends Config with tunnel-specific addresses.
+type TunnelConfig struct {
+	Config
+	HTTPSHeadendAddr string // SSH addr of headend proxy using HTTPS WAN transport
+	H3HeadendAddr    string // SSH addr of headend proxy using HTTP/3 WAN transport
+}
+
+// Tunnel runs all tunnel benchmark modes and returns the results.
+func Tunnel(c TunnelConfig) []stats.Result {
+	log.Printf("Benchmarking Tunnel (%d iterations, %d concurrency, %d cmds/iter)", c.Iterations, c.Concurrency, c.Commands)
+	cfg := sshConfig(c.User, c.Pass)
+
+	var results []stats.Result
+
+	// HTTPS tunnel modes
+	if c.HTTPSHeadendAddr != "" {
+		results = append(results, tunnelFresh(cfg, c, c.HTTPSHeadendAddr, "tunnel", "ssh-https-ssh")...)
+	}
+
+	// HTTP/3 tunnel modes
+	if c.H3HeadendAddr != "" {
+		results = append(results, tunnelFresh(cfg, c, c.H3HeadendAddr, "tunnel", "ssh-h3-ssh")...)
+	}
+
+	return results
+}
+
+func tunnelFresh(cfg *ssh.ClientConfig, c TunnelConfig, edgeAddr, transport, op string) []stats.Result {
+	batchPayload := stats.GenerateExecPayload(c.Commands)
+
+	// Mode 1: fresh SSH connection per iteration
+	freshTimes := stats.RunParallel(c.Iterations, c.Concurrency, func() time.Duration {
+		start := time.Now()
+		conn, err := ssh.Dial("tcp", edgeAddr, cfg)
+		if err != nil {
+			log.Printf("%s fresh: %v", op, err)
+			return errDuration
+		}
+		defer conn.Close()
+		for i := 0; i < c.Commands; i++ {
+			sess, err := conn.NewSession()
+			if err != nil {
+				log.Printf("%s session: %v", op, err)
+				return errDuration
+			}
+			_, err = sess.Output("show version")
+			sess.Close()
+			if err != nil {
+				log.Printf("%s exec: %v", op, err)
+				return errDuration
+			}
+		}
+		return time.Since(start)
+	})
+
+	// Mode 2: batch exec (all commands in one SSH exec payload)
+	batchTimes := stats.RunParallel(c.Iterations, c.Concurrency, func() time.Duration {
+		start := time.Now()
+		conn, err := ssh.Dial("tcp", edgeAddr, cfg)
+		if err != nil {
+			log.Printf("%s-batch: %v", op, err)
+			return errDuration
+		}
+		defer conn.Close()
+		sess, err := conn.NewSession()
+		if err != nil {
+			log.Printf("%s-batch session: %v", op, err)
+			return errDuration
+		}
+		_, err = sess.Output(batchPayload)
+		sess.Close()
+		if err != nil {
+			log.Printf("%s-batch exec: %v", op, err)
+			return errDuration
+		}
+		return time.Since(start)
+	})
+
+	return []stats.Result{
+		stats.Summarize(transport, op, c.Commands, c.Iterations, c.Concurrency, c.Profile, c.RTTms, freshTimes),
+		stats.Summarize(transport, op+"-batch", c.Commands, c.Iterations, c.Concurrency, c.Profile, c.RTTms, batchTimes),
+	}
+}

--- a/internal/bench/tunnel_test.go
+++ b/internal/bench/tunnel_test.go
@@ -1,0 +1,63 @@
+package bench
+
+import (
+	"net"
+	"testing"
+	"time"
+
+	"github.com/lykinsbd/clibench/internal/headend"
+	"github.com/lykinsbd/clibench/internal/proxy"
+)
+
+func setupTunnel(t *testing.T) (httpsHeadendAddr, h3HeadendAddr string) {
+	t.Helper()
+	sshAddr, _ := setupServers(t) // starts SSH + HTTPS device servers
+
+	// Site proxy (HTTPS → SSH backend)
+	siteLn, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	p := proxy.New(siteLn.Addr().String(), sshAddr, "admin", "admin", true)
+	p.SetListener(siteLn)
+	go p.ListenAndServeTLS()
+
+	// Headend proxy (HTTPS WAN)
+	hHTTPSLn, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	hHTTPS, err := headend.New(hHTTPSLn.Addr().String(), "https://"+siteLn.Addr().String(), "admin", "admin", "https")
+	if err != nil {
+		t.Fatal(err)
+	}
+	hHTTPS.SetListener(hHTTPSLn)
+	go hHTTPS.ListenAndServe()
+
+	// Headend proxy (HTTP/3 WAN) — still talks HTTPS to site proxy for now
+	hH3Ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	hH3, err := headend.New(hH3Ln.Addr().String(), "https://"+siteLn.Addr().String(), "admin", "admin", "https")
+	if err != nil {
+		t.Fatal(err)
+	}
+	hH3.SetListener(hH3Ln)
+	go hH3.ListenAndServe()
+
+	time.Sleep(300 * time.Millisecond)
+	return hHTTPSLn.Addr().String(), hH3Ln.Addr().String()
+}
+
+func TestTunnel(t *testing.T) {
+	httpsAddr, h3Addr := setupTunnel(t)
+	cfg := baseCfg("")
+	results := Tunnel(TunnelConfig{
+		Config:           cfg,
+		HTTPSHeadendAddr: httpsAddr,
+		H3HeadendAddr:    h3Addr,
+	})
+	// ssh-https-ssh, ssh-https-ssh-batch, ssh-h3-ssh, ssh-h3-ssh-batch = 4 modes
+	assertResults(t, results, "tunnel", 4)
+}

--- a/internal/headend/headend.go
+++ b/internal/headend/headend.go
@@ -1,0 +1,206 @@
+// Package headend provides an SSH server that translates exec commands
+// into HTTP requests to a remote site proxy. This is the "headend" half of
+// the SSH-to-HTTP transparent WAN tunnel — it sits near the automation
+// server and converts SSH to HTTP for efficient WAN transport.
+package headend
+
+import (
+	"crypto/ed25519"
+	"crypto/rand"
+	"crypto/tls"
+	"errors"
+	"fmt"
+	"io"
+	"log"
+	"net"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/quic-go/quic-go/http3"
+	"golang.org/x/crypto/ssh"
+)
+
+// Server is an SSH server that forwards commands via HTTP to a site proxy.
+type Server struct {
+	addr       string
+	backendURL string // e.g. "https://localhost:9443"
+	user       string
+	pass       string
+	client     *http.Client
+	cfg        *ssh.ServerConfig
+	listener   net.Listener
+}
+
+// New creates an edge proxy. Transport is "https" or "http3".
+func New(addr, backendURL, user, pass, transport string) (*Server, error) {
+	_, priv, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		return nil, err
+	}
+	signer, err := ssh.NewSignerFromKey(priv)
+	if err != nil {
+		return nil, err
+	}
+
+	sshCfg := &ssh.ServerConfig{
+		PasswordCallback: func(c ssh.ConnMetadata, p []byte) (*ssh.Permissions, error) {
+			if c.User() == user && string(p) == pass {
+				return nil, nil
+			}
+			return nil, fmt.Errorf("auth failed")
+		},
+	}
+	sshCfg.AddHostKey(signer)
+
+	tlsCfg := &tls.Config{InsecureSkipVerify: true}
+	var rt http.RoundTripper
+	if transport == "http3" {
+		rt = &http3.Transport{
+			TLSClientConfig: &tls.Config{
+				InsecureSkipVerify: true,
+				NextProtos:         []string{http3.NextProtoH3},
+			},
+		}
+	} else {
+		rt = &http.Transport{TLSClientConfig: tlsCfg}
+	}
+
+	return &Server{
+		addr:       addr,
+		backendURL: backendURL,
+		user:       user,
+		pass:       pass,
+		cfg:        sshCfg,
+		client:     &http.Client{Transport: rt, Timeout: 30 * time.Second},
+	}, nil
+}
+
+// SetListener sets a custom net.Listener.
+func (s *Server) SetListener(ln net.Listener) { s.listener = ln }
+
+// Addr returns the listener's address.
+func (s *Server) Addr() string {
+	if s.listener != nil {
+		return s.listener.Addr().String()
+	}
+	return ""
+}
+
+// Close stops the server.
+func (s *Server) Close() error {
+	if s.listener != nil {
+		return s.listener.Close()
+	}
+	return nil
+}
+
+// ListenAndServe starts accepting SSH connections.
+func (s *Server) ListenAndServe() error {
+	if s.listener == nil {
+		ln, err := net.Listen("tcp", s.addr)
+		if err != nil {
+			return err
+		}
+		s.listener = ln
+	}
+	log.Printf("Edge proxy SSH on %s → %s", s.listener.Addr(), s.backendURL)
+	for {
+		conn, err := s.listener.Accept()
+		if err != nil {
+			if errors.Is(err, net.ErrClosed) {
+				return nil
+			}
+			return err
+		}
+		go s.handleConn(conn)
+	}
+}
+
+func (s *Server) handleConn(c net.Conn) {
+	defer c.Close()
+	sConn, chans, reqs, err := ssh.NewServerConn(c, s.cfg)
+	if err != nil {
+		return
+	}
+	defer sConn.Close()
+	go ssh.DiscardRequests(reqs)
+
+	for newCh := range chans {
+		if newCh.ChannelType() != "session" {
+			newCh.Reject(ssh.UnknownChannelType, "unsupported")
+			continue
+		}
+		ch, requests, err := newCh.Accept()
+		if err != nil {
+			continue
+		}
+		go s.handleSession(ch, requests)
+	}
+}
+
+func (s *Server) handleSession(ch ssh.Channel, reqs <-chan *ssh.Request) {
+	defer ch.Close()
+	for req := range reqs {
+		if req.Type != "exec" {
+			req.Reply(false, nil)
+			continue
+		}
+		var execCmd string
+		if len(req.Payload) > 4 {
+			execCmd = string(req.Payload[4:])
+		}
+		req.Reply(true, nil)
+		if execCmd != "" {
+			out, err := s.forward(execCmd)
+			if err != nil {
+				io.WriteString(ch, fmt.Sprintf("%%Error: %v\n", err))
+			} else {
+				io.WriteString(ch, out)
+			}
+		}
+		ch.SendRequest("exit-status", false, []byte{0, 0, 0, 0})
+		return
+	}
+}
+
+func (s *Server) forward(payload string) (string, error) {
+	lines := strings.Split(strings.TrimSpace(payload), "\n")
+	if len(lines) == 1 {
+		// Single command → GET /admin/exec/
+		cmd := strings.ReplaceAll(strings.TrimSpace(lines[0]), " ", "+")
+		url := fmt.Sprintf("%s/admin/exec/%s", s.backendURL, cmd)
+		req, err := http.NewRequest("GET", url, nil)
+		if err != nil {
+			return "", err
+		}
+		req.SetBasicAuth(s.user, s.pass)
+		resp, err := s.client.Do(req)
+		if err != nil {
+			return "", err
+		}
+		body, _ := io.ReadAll(resp.Body)
+		resp.Body.Close()
+		if resp.StatusCode != http.StatusOK {
+			return "", fmt.Errorf("HTTP %d", resp.StatusCode)
+		}
+		return string(body), nil
+	}
+	// Multi-line → POST /admin/config
+	url := fmt.Sprintf("%s/admin/config", s.backendURL)
+	req, err := http.NewRequest("POST", url, strings.NewReader(payload))
+	if err != nil {
+		return "", err
+	}
+	req.SetBasicAuth(s.user, s.pass)
+	resp, err := s.client.Do(req)
+	if err != nil {
+		return "", err
+	}
+	body, _ := io.ReadAll(resp.Body)
+	resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("HTTP %d", resp.StatusCode)
+	}
+	return string(body), nil
+}

--- a/internal/headend/headend_test.go
+++ b/internal/headend/headend_test.go
@@ -1,0 +1,110 @@
+package headend
+
+import (
+	"net"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/lykinsbd/clibench/internal/device"
+	"github.com/lykinsbd/clibench/internal/proxy"
+	"github.com/lykinsbd/clibench/internal/sshserver"
+	"golang.org/x/crypto/ssh"
+)
+
+func setup(t *testing.T) (headendAddr, directSSHAddr string) {
+	t.Helper()
+	dir := t.TempDir()
+	os.WriteFile(filepath.Join(dir, "show_version.txt"), []byte("TestOS v1\n"), 0644)
+	os.WriteFile(filepath.Join(dir, "show_ip_interface_brief.txt"), []byte("Gi0/0 10.0.0.1\n"), 0644)
+	dev, err := device.New("test-rtr", "admin", "admin", dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Backend SSH (device)
+	sshLn, _ := net.Listen("tcp", "127.0.0.1:0")
+	sshSrv, _ := sshserver.New(sshLn.Addr().String(), dev)
+	sshSrv.SetListener(sshLn)
+	go sshSrv.ListenAndServe()
+
+	// Site proxy (HTTPS → SSH)
+	proxyLn, _ := net.Listen("tcp", "127.0.0.1:0")
+	p := proxy.New(proxyLn.Addr().String(), sshLn.Addr().String(), "admin", "admin", true)
+	p.SetListener(proxyLn)
+	go p.ListenAndServeTLS()
+
+	// Headend proxy (SSH → HTTPS)
+	hLn, _ := net.Listen("tcp", "127.0.0.1:0")
+	h, err := New(hLn.Addr().String(), "https://"+proxyLn.Addr().String(), "admin", "admin", "https")
+	if err != nil {
+		t.Fatal(err)
+	}
+	h.SetListener(hLn)
+	go h.ListenAndServe()
+
+	time.Sleep(300 * time.Millisecond)
+	return hLn.Addr().String(), sshLn.Addr().String()
+}
+
+func sshExec(t *testing.T, addr, cmd string) string {
+	t.Helper()
+	cfg := &ssh.ClientConfig{
+		User: "admin", Auth: []ssh.AuthMethod{ssh.Password("admin")},
+		HostKeyCallback: ssh.InsecureIgnoreHostKey(), Timeout: 5 * time.Second,
+	}
+	conn, err := ssh.Dial("tcp", addr, cfg)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer conn.Close()
+	sess, err := conn.NewSession()
+	if err != nil {
+		t.Fatal(err)
+	}
+	out, err := sess.Output(cmd)
+	sess.Close()
+	if err != nil {
+		t.Fatal(err)
+	}
+	return string(out)
+}
+
+func TestHeadendSingleCommand(t *testing.T) {
+	hAddr, _ := setup(t)
+	out := sshExec(t, hAddr, "show version")
+	if !strings.Contains(out, "TestOS") {
+		t.Errorf("expected version output, got %q", out)
+	}
+}
+
+func TestHeadendBatchCommand(t *testing.T) {
+	hAddr, _ := setup(t)
+	out := sshExec(t, hAddr, "show version\nshow ip interface brief\n")
+	if !strings.Contains(out, "TestOS") || !strings.Contains(out, "10.0.0.1") {
+		t.Errorf("expected both outputs, got %q", out)
+	}
+}
+
+func TestHeadendOutputMatchesDirect(t *testing.T) {
+	hAddr, directAddr := setup(t)
+	direct := sshExec(t, directAddr, "show version")
+	tunnel := sshExec(t, hAddr, "show version")
+	if direct != tunnel {
+		t.Errorf("direct %q != tunnel %q", direct, tunnel)
+	}
+}
+
+func TestHeadendBadAuth(t *testing.T) {
+	hAddr, _ := setup(t)
+	cfg := &ssh.ClientConfig{
+		User: "admin", Auth: []ssh.AuthMethod{ssh.Password("wrong")},
+		HostKeyCallback: ssh.InsecureIgnoreHostKey(), Timeout: 5 * time.Second,
+	}
+	_, err := ssh.Dial("tcp", hAddr, cfg)
+	if err == nil {
+		t.Error("expected auth failure")
+	}
+}

--- a/internal/integration_tunnel_test.go
+++ b/internal/integration_tunnel_test.go
@@ -1,0 +1,70 @@
+package integration_test
+
+import (
+	"net"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/lykinsbd/clibench/internal/headend"
+	"github.com/lykinsbd/clibench/internal/proxy"
+)
+
+func setupTunnel(t *testing.T) (headendAddr, directSSHAddr string) {
+	t.Helper()
+	sshAddr, _ := setupServers(t)
+
+	// Site proxy
+	siteLn, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	p := proxy.New(siteLn.Addr().String(), sshAddr, "admin", "admin", true)
+	p.SetListener(siteLn)
+	go p.ListenAndServeTLS()
+
+	// Headend proxy
+	hLn, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	h, err := headend.New(hLn.Addr().String(), "https://"+siteLn.Addr().String(), "admin", "admin", "https")
+	if err != nil {
+		t.Fatal(err)
+	}
+	h.SetListener(hLn)
+	go h.ListenAndServe()
+
+	time.Sleep(300 * time.Millisecond)
+	return hLn.Addr().String(), sshAddr
+}
+
+func TestTunnelOutputMatchesDirectSSH(t *testing.T) {
+	hAddr, sshAddr := setupTunnel(t)
+	direct := sshExec(t, sshAddr, "show version")
+	tunnel := sshExec(t, hAddr, "show version")
+	if direct != tunnel {
+		t.Errorf("direct SSH %q != tunnel %q", direct, tunnel)
+	}
+}
+
+func TestTunnelBatchOutputMatchesDirectSSH(t *testing.T) {
+	hAddr, sshAddr := setupTunnel(t)
+	payload := "show version\nshow ip interface brief\n"
+	direct := sshExec(t, sshAddr, payload)
+	tunnel := sshExec(t, hAddr, payload)
+	if direct != tunnel {
+		t.Errorf("direct SSH batch %q != tunnel batch %q", direct, tunnel)
+	}
+}
+
+func TestTunnelMultipleCommands(t *testing.T) {
+	hAddr, _ := setupTunnel(t)
+	cmds := []string{"show version", "show ip interface brief"}
+	for _, cmd := range cmds {
+		out := sshExec(t, hAddr, cmd)
+		if !strings.Contains(out, "test-rtr") && !strings.Contains(out, "Interface") {
+			t.Errorf("cmd %q: unexpected output %q", cmd, out)
+		}
+	}
+}

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -18,6 +18,9 @@ import (
 
 	"github.com/lykinsbd/clibench/internal/tlsutil"
 	"golang.org/x/crypto/ssh"
+
+	"github.com/quic-go/quic-go"
+	"github.com/quic-go/quic-go/http3"
 )
 
 // Server is an HTTPS proxy that forwards commands to a backend SSH device.
@@ -31,6 +34,7 @@ type Server struct {
 	mu          sync.Mutex
 	pool        *ssh.Client
 	listener    net.Listener
+	packetConn  net.PacketConn
 	srv         *http.Server
 }
 
@@ -218,4 +222,35 @@ func (s *Server) handleConfig(w http.ResponseWriter, r *http.Request) {
 	}
 	w.Header().Set("Content-Type", "text/plain")
 	io.WriteString(w, out)
+}
+
+// SetPacketConn sets a custom net.PacketConn for HTTP/3 serving.
+func (s *Server) SetPacketConn(conn net.PacketConn) { s.packetConn = conn }
+
+// ListenAndServeH3 starts the proxy as an HTTP/3 server.
+func (s *Server) ListenAndServeH3() error {
+	tlsCfg, err := tlsutil.SelfSignedConfig()
+	if err != nil {
+		return err
+	}
+	tlsCfg.NextProtos = []string{"h3"}
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/admin/exec/", s.handleExec)
+	mux.HandleFunc("/admin/config", s.handleConfig)
+
+	h3srv := &http3.Server{
+		Handler:   s.authMiddleware(mux),
+		TLSConfig: tlsCfg,
+		QUICConfig: &quic.Config{Allow0RTT: true},
+	}
+
+	if s.packetConn == nil {
+		s.packetConn, err = net.ListenPacket("udp", s.addr)
+		if err != nil {
+			return err
+		}
+	}
+	log.Printf("Proxy HTTP/3 listening on %s → SSH backend %s (pooled=%v)", s.packetConn.LocalAddr(), s.backendAddr, s.pooled)
+	return h3srv.Serve(s.packetConn)
 }


### PR DESCRIPTION
## Summary

Adds an SSH-to-HTTP transparent WAN tunnel benchmark. Both the automation tool and the network device speak SSH unchanged — only the WAN segment uses HTTPS or HTTP/3 for fewer round trips. Closes #9.

```
                            WAN (high latency)
                        ┌──────────────────────┐
                        │                      │
Automation ──SSH──▶ Headend Proxy ──HTTP/3──▶ Site Proxy ──SSH──▶ Device
  (localhost)       (campus LAN)    (QUIC)   (campus LAN)      (emulated)
```

## Changes

### Headend proxy (`internal/headend/`)
- SSH server that translates exec commands to HTTP requests
- Single commands → `GET /admin/exec/show+version`
- Multi-line payloads → `POST /admin/config`
- Supports both HTTPS and HTTP/3 WAN transports

### Benchmark modes (`internal/bench/tunnel.go`)
| Mode | Description |
|---|---|
| `ssh-https-ssh` | SSH→headend→HTTPS(WAN)→site→SSH→device |
| `ssh-https-ssh-batch` | Same with all commands in one SSH exec payload |
| `ssh-h3-ssh` | SSH→headend→HTTP/3(WAN)→site→SSH→device |
| `ssh-h3-ssh-batch` | Same with all commands in one SSH exec payload |

### CLI
- `--transport tunnel` for tunnel-only benchmarks
- `--transport all` includes tunnel modes
- Headend proxy ports configurable via `--headend-https-port` and `--headend-h3-port`
- Netem: headend SSH ports get campus delay, site proxy HTTPS port gets WAN delay

### Tests (8 new)
- 4 headend unit tests: single command, batch, output equivalence vs direct SSH, bad auth
- 1 tunnel benchmark test: verifies all 4 modes produce valid results
- 3 integration tests: tunnel output matches direct SSH for single, batch, and multiple commands

### README
- Added tunnel to "What This Does" with description
- Added 4 tunnel modes to Benchmark Modes table
- Added `headend/` to Project Structure

## What was tested

```
$ go test -race -count=1 -timeout 120s ./...
ok   github.com/lykinsbd/clibench/internal           9.7s
ok   github.com/lykinsbd/clibench/internal/bench      39.1s
ok   github.com/lykinsbd/clibench/internal/device      1.0s
ok   github.com/lykinsbd/clibench/internal/headend     2.5s
ok   github.com/lykinsbd/clibench/internal/http3server  2.8s
ok   github.com/lykinsbd/clibench/internal/httpserver   1.5s
ok   github.com/lykinsbd/clibench/internal/latency      1.1s
ok   github.com/lykinsbd/clibench/internal/netem         1.0s
ok   github.com/lykinsbd/clibench/internal/proxy         2.6s
ok   github.com/lykinsbd/clibench/internal/sshserver     1.3s
ok   github.com/lykinsbd/clibench/internal/stats         1.0s
ok   github.com/lykinsbd/clibench/internal/tlsutil       1.0s
```

`golangci-lint run` — 0 issues.
