### PR TITLE
feat: measure actual round-trip counts per benchmark mode

### DIFF
--- a/cmd/clibench/format.go
+++ b/cmd/clibench/format.go
@@ -11,11 +11,11 @@ import (
 
 func writeTable(w io.Writer, results []stats.Result) error {
 	tw := tabwriter.NewWriter(w, 0, 4, 2, ' ', 0)
-	fmt.Fprintln(tw, "TRANSPORT\tOPERATION\tCMDS\tITER\tERR\tAVG(ms)\tMIN(ms)\tP50(ms)\tP95(ms)\tMAX(ms)\tSTDDEV")
+	fmt.Fprintln(tw, "TRANSPORT\tOPERATION\tCMDS\tITER\tERR\tRT\tAVG(ms)\tMIN(ms)\tP50(ms)\tP95(ms)\tMAX(ms)\tSTDDEV")
 	for _, r := range results {
-		fmt.Fprintf(tw, "%s\t%s\t%d\t%d\t%d\t%.2f\t%.2f\t%.2f\t%.2f\t%.2f\t%.2f\n",
+		fmt.Fprintf(tw, "%s\t%s\t%d\t%d\t%d\t%d\t%.2f\t%.2f\t%.2f\t%.2f\t%.2f\t%.2f\n",
 			r.Transport, r.Operation, r.Commands, r.Iterations, r.Errors,
-			r.AvgMs, r.MinMs, r.P50Ms, r.P95Ms, r.MaxMs, r.StddevMs)
+			r.RoundTrips, r.AvgMs, r.MinMs, r.P50Ms, r.P95Ms, r.MaxMs, r.StddevMs)
 	}
 	return tw.Flush()
 }
@@ -24,7 +24,7 @@ func writeCSV(w io.Writer, results []stats.Result) error {
 	cw := csv.NewWriter(w)
 	_ = cw.Write([]string{
 		"transport", "operation", "commands", "iterations", "errors",
-		"concurrency", "latency_profile", "simulated_rtt_ms",
+		"concurrency", "latency_profile", "simulated_rtt_ms", "round_trips",
 		"avg_ms", "min_ms", "max_ms", "p50_ms", "p95_ms", "stddev_ms",
 	})
 	for _, r := range results {
@@ -33,6 +33,7 @@ func writeCSV(w io.Writer, results []stats.Result) error {
 			fmt.Sprintf("%d", r.Commands), fmt.Sprintf("%d", r.Iterations),
 			fmt.Sprintf("%d", r.Errors), fmt.Sprintf("%d", r.Concurrency),
 			r.Latency, fmt.Sprintf("%.1f", r.RTTms),
+			fmt.Sprintf("%d", r.RoundTrips),
 			fmt.Sprintf("%.3f", r.AvgMs), fmt.Sprintf("%.3f", r.MinMs),
 			fmt.Sprintf("%.3f", r.MaxMs), fmt.Sprintf("%.3f", r.P50Ms),
 			fmt.Sprintf("%.3f", r.P95Ms), fmt.Sprintf("%.3f", r.StddevMs),

--- a/internal/bench/bench.go
+++ b/internal/bench/bench.go
@@ -2,14 +2,17 @@
 package bench
 
 import (
+	"context"
 	"crypto/tls"
 	"fmt"
 	"io"
 	"log"
+	"net"
 	"net/http"
 	"strings"
 	"time"
 
+	"github.com/lykinsbd/clibench/internal/rtcount"
 	"github.com/lykinsbd/clibench/internal/stats"
 	"golang.org/x/crypto/ssh"
 )
@@ -48,15 +51,31 @@ func sshConfig(user, pass string) *ssh.ClientConfig {
 	}
 }
 
+// sshDialCounted dials an SSH connection over a counted net.Conn.
+func sshDialCounted(addr string, cfg *ssh.ClientConfig) (*ssh.Client, *rtcount.Conn, error) {
+	tc, err := net.DialTimeout("tcp", addr, cfg.Timeout)
+	if err != nil {
+		return nil, nil, err
+	}
+	cc := rtcount.Wrap(tc)
+	sconn, chans, reqs, err := ssh.NewClientConn(cc, addr, cfg)
+	if err != nil {
+		tc.Close()
+		return nil, nil, err
+	}
+	return ssh.NewClient(sconn, chans, reqs), cc, nil
+}
+
 // SSH runs all SSH benchmark modes and returns the results.
 func SSH(c Config) []stats.Result {
 	log.Printf("Benchmarking SSH (%d iterations, %d concurrency, %d cmds/iter)", c.Iterations, c.Concurrency, c.Commands)
 	cfg := sshConfig(c.User, c.Pass)
 
 	// Mode 1: fresh connection per iteration
-	freshTimes := stats.RunParallel(c.Iterations, c.Concurrency, func() time.Duration {
+	freshTrips := make([]int, c.Iterations)
+	freshTimes := stats.RunParallel(c.Iterations, c.Concurrency, func(idx int) time.Duration {
 		start := time.Now()
-		conn, err := ssh.Dial("tcp", c.Addr, cfg)
+		conn, cc, err := sshDialCounted(c.Addr, cfg)
 		if err != nil {
 			log.Printf("ssh dial: %v", err)
 			return errDuration
@@ -75,12 +94,14 @@ func SSH(c Config) []stats.Result {
 				return errDuration
 			}
 		}
+		freshTrips[idx] = cc.Trips()
 		return time.Since(start)
 	})
 
 	// Mode 2: reuse one connection (ControlMaster-style)
-	sharedConn, err := ssh.Dial("tcp", c.Addr, cfg)
+	sharedConn, sharedCC, err := sshDialCounted(c.Addr, cfg)
 	var reuseTimes []time.Duration
+	var reuseTrips []int
 	if err != nil {
 		log.Printf("ssh reuse dial: %v (skipping reuse test)", err)
 	} else {
@@ -88,7 +109,10 @@ func SSH(c Config) []stats.Result {
 			_, _ = sess.Output("show version")
 			sess.Close()
 		}
-		reuseTimes = stats.RunParallel(c.Iterations, c.Concurrency, func() time.Duration {
+		baseTrips := sharedCC.Trips()
+		reuseTrips = make([]int, c.Iterations)
+		reuseTimes = stats.RunParallel(c.Iterations, c.Concurrency, func(idx int) time.Duration {
+			before := sharedCC.Trips()
 			start := time.Now()
 			for i := 0; i < c.Commands; i++ {
 				sess, err := sharedConn.NewSession()
@@ -103,16 +127,19 @@ func SSH(c Config) []stats.Result {
 					return errDuration
 				}
 			}
+			reuseTrips[idx] = sharedCC.Trips() - before
 			return time.Since(start)
 		})
+		_ = baseTrips
 		sharedConn.Close()
 	}
 
 	// Mode 3: batch exec
 	batchPayload := stats.GenerateExecPayload(c.Commands)
-	batchTimes := stats.RunParallel(c.Iterations, c.Concurrency, func() time.Duration {
+	batchTrips := make([]int, c.Iterations)
+	batchTimes := stats.RunParallel(c.Iterations, c.Concurrency, func(idx int) time.Duration {
 		start := time.Now()
-		conn, err := ssh.Dial("tcp", c.Addr, cfg)
+		conn, cc, err := sshDialCounted(c.Addr, cfg)
 		if err != nil {
 			log.Printf("ssh batch dial: %v", err)
 			return errDuration
@@ -129,22 +156,24 @@ func SSH(c Config) []stats.Result {
 			log.Printf("ssh batch exec: %v", err)
 			return errDuration
 		}
+		batchTrips[idx] = cc.Trips()
 		return time.Since(start)
 	})
 
 	results := []stats.Result{
-		stats.Summarize("ssh", "fresh-conn", c.Commands, c.Iterations, c.Concurrency, c.Profile, c.RTTms, freshTimes),
+		stats.Summarize("ssh", "fresh-conn", c.Commands, c.Iterations, c.Concurrency, c.Profile, c.RTTms, freshTimes, freshTrips),
 	}
 	if reuseTimes != nil {
-		results = append(results, stats.Summarize("ssh", "reuse-conn", c.Commands, c.Iterations, c.Concurrency, c.Profile, c.RTTms, reuseTimes))
+		results = append(results, stats.Summarize("ssh", "reuse-conn", c.Commands, c.Iterations, c.Concurrency, c.Profile, c.RTTms, reuseTimes, reuseTrips))
 	}
-	results = append(results, stats.Summarize("ssh", "batch-exec", c.Commands, c.Iterations, c.Concurrency, c.Profile, c.RTTms, batchTimes))
+	results = append(results, stats.Summarize("ssh", "batch-exec", c.Commands, c.Iterations, c.Concurrency, c.Profile, c.RTTms, batchTimes, batchTrips))
 
 	// Mode 4: PTY/shell — fresh connection per iteration
 	prompt := c.Hostname + "#"
-	ptyFreshTimes := stats.RunParallel(c.Iterations, c.Concurrency, func() time.Duration {
+	ptyFreshTrips := make([]int, c.Iterations)
+	ptyFreshTimes := stats.RunParallel(c.Iterations, c.Concurrency, func(idx int) time.Duration {
 		start := time.Now()
-		conn, err := ssh.Dial("tcp", c.Addr, cfg)
+		conn, cc, err := sshDialCounted(c.Addr, cfg)
 		if err != nil {
 			log.Printf("ssh pty dial: %v", err)
 			return errDuration
@@ -159,14 +188,21 @@ func SSH(c Config) []stats.Result {
 			log.Printf("ssh pty-fresh: %v", err)
 			return errDuration
 		}
+		ptyFreshTrips[idx] = cc.Trips()
 		return time.Since(start)
 	})
-	results = append(results, stats.Summarize("ssh", "pty-fresh", c.Commands, c.Iterations, c.Concurrency, c.Profile, c.RTTms, ptyFreshTimes))
+	results = append(results, stats.Summarize("ssh", "pty-fresh", c.Commands, c.Iterations, c.Concurrency, c.Profile, c.RTTms, ptyFreshTimes, ptyFreshTrips))
 
 	// Mode 5: PTY/shell — reuse connection
-	ptyConn, err := ssh.Dial("tcp", c.Addr, cfg)
+	ptyConn, ptyCC, err := sshDialCounted(c.Addr, cfg)
 	if err == nil {
-		ptyReuseTimes := stats.RunParallel(c.Iterations, c.Concurrency, func() time.Duration {
+		if sess, err := ptyConn.NewSession(); err == nil {
+			_ = ptyExecCmds(sess, prompt, 1)
+			sess.Close()
+		}
+		ptyReuseTrips := make([]int, c.Iterations)
+		ptyReuseTimes := stats.RunParallel(c.Iterations, c.Concurrency, func(idx int) time.Duration {
+			before := ptyCC.Trips()
 			start := time.Now()
 			sess, err := ptyConn.NewSession()
 			if err != nil {
@@ -177,10 +213,11 @@ func SSH(c Config) []stats.Result {
 				log.Printf("ssh pty-reuse: %v", err)
 				return errDuration
 			}
+			ptyReuseTrips[idx] = ptyCC.Trips() - before
 			return time.Since(start)
 		})
 		ptyConn.Close()
-		results = append(results, stats.Summarize("ssh", "pty-reuse", c.Commands, c.Iterations, c.Concurrency, c.Profile, c.RTTms, ptyReuseTimes))
+		results = append(results, stats.Summarize("ssh", "pty-reuse", c.Commands, c.Iterations, c.Concurrency, c.Profile, c.RTTms, ptyReuseTimes, ptyReuseTrips))
 	}
 
 	return results
@@ -192,53 +229,105 @@ func HTTPS(c Config) []stats.Result {
 
 	tlsCfg := &tls.Config{InsecureSkipVerify: true}
 
-	// Mode 1: fresh connection per iteration
-	freshTimes := stats.RunParallel(c.Iterations, c.Concurrency, func() time.Duration {
-		start := time.Now()
-		client := &http.Client{
-			Transport: &http.Transport{
-				TLSClientConfig:   tlsCfg,
-				DisableKeepAlives: true,
+	// countingTransport returns an http.Transport that wraps connections with rtcount.
+	// The returned *rtcount.Conn pointer is set on first dial.
+	countingTransport := func(disableKeepAlive bool) (*http.Transport, **rtcount.Conn) {
+		cc := new(*rtcount.Conn)
+		tr := &http.Transport{
+			TLSClientConfig:   tlsCfg,
+			DisableKeepAlives: disableKeepAlive,
+			DialTLSContext: func(ctx context.Context, network, addr string) (net.Conn, error) {
+				tc, err := net.Dial(network, addr)
+				if err != nil {
+					return nil, err
+				}
+				wrapped := rtcount.Wrap(tc)
+				*cc = wrapped
+				tlsConn := tls.Client(wrapped, tlsCfg)
+				if err := tlsConn.HandshakeContext(ctx); err != nil {
+					tc.Close()
+					return nil, err
+				}
+				return tlsConn, nil
 			},
-			Timeout: 30 * time.Second,
 		}
+		return tr, cc
+	}
+
+	// Mode 1: fresh connection per iteration
+	freshTrips := make([]int, c.Iterations)
+	freshTimes := stats.RunParallel(c.Iterations, c.Concurrency, func(idx int) time.Duration {
+		start := time.Now()
+		var conns []*rtcount.Conn
+		tr := &http.Transport{
+			TLSClientConfig:   tlsCfg,
+			DisableKeepAlives: true,
+			DialTLSContext: func(ctx context.Context, network, addr string) (net.Conn, error) {
+				tc, err := net.Dial(network, addr)
+				if err != nil {
+					return nil, err
+				}
+				wrapped := rtcount.Wrap(tc)
+				conns = append(conns, wrapped)
+				tlsConn := tls.Client(wrapped, tlsCfg)
+				if err := tlsConn.HandshakeContext(ctx); err != nil {
+					tc.Close()
+					return nil, err
+				}
+				return tlsConn, nil
+			},
+		}
+		client := &http.Client{Transport: tr, Timeout: 30 * time.Second}
 		for i := 0; i < c.Commands; i++ {
 			if err := doHTTPExec(client, c.Addr, c.User, c.Pass); err != nil {
 				log.Printf("https fresh: %v", err)
 				return errDuration
 			}
 		}
+		total := 0
+		for _, cc := range conns {
+			total += cc.Trips()
+		}
+		freshTrips[idx] = total
 		return time.Since(start)
 	})
 
-	// Mode 2: keep-alive
-	keepAliveClient := &http.Client{
-		Transport: &http.Transport{TLSClientConfig: tlsCfg},
-		Timeout:   30 * time.Second,
-	}
-	_ = doHTTPExec(keepAliveClient, c.Addr, c.User, c.Pass)
+	// Mode 2: keep-alive — shared connection, count per iteration
+	keepTr, keepCC := countingTransport(false)
+	keepClient := &http.Client{Transport: keepTr, Timeout: 30 * time.Second}
+	_ = doHTTPExec(keepClient, c.Addr, c.User, c.Pass)
 
-	reuseTimes := stats.RunParallel(c.Iterations, c.Concurrency, func() time.Duration {
+	keepTrips := make([]int, c.Iterations)
+	reuseTimes := stats.RunParallel(c.Iterations, c.Concurrency, func(idx int) time.Duration {
+		var before int
+		if *keepCC != nil {
+			before = (*keepCC).Trips()
+		}
 		start := time.Now()
 		for i := 0; i < c.Commands; i++ {
-			if err := doHTTPExec(keepAliveClient, c.Addr, c.User, c.Pass); err != nil {
+			if err := doHTTPExec(keepClient, c.Addr, c.User, c.Pass); err != nil {
 				log.Printf("https keep-alive: %v", err)
 				return errDuration
 			}
 		}
+		if *keepCC != nil {
+			keepTrips[idx] = (*keepCC).Trips() - before
+		}
 		return time.Since(start)
 	})
 
-	// Mode 3: batch POST — reuses TLS connection so we measure the
-	// payload strategy, not connection setup.
+	// Mode 3: batch POST
 	batchPayload := stats.GenerateExecPayload(c.Commands)
-	batchClient := &http.Client{
-		Transport: &http.Transport{TLSClientConfig: tlsCfg},
-		Timeout:   30 * time.Second,
-	}
-	_ = doHTTPExec(batchClient, c.Addr, c.User, c.Pass) // warmup
+	batchTr, batchCC := countingTransport(false)
+	batchClient := &http.Client{Transport: batchTr, Timeout: 30 * time.Second}
+	_ = doHTTPExec(batchClient, c.Addr, c.User, c.Pass)
 
-	batchTimes := stats.RunParallel(c.Iterations, c.Concurrency, func() time.Duration {
+	batchTrips := make([]int, c.Iterations)
+	batchTimes := stats.RunParallel(c.Iterations, c.Concurrency, func(idx int) time.Duration {
+		var before int
+		if *batchCC != nil {
+			before = (*batchCC).Trips()
+		}
 		start := time.Now()
 		url := fmt.Sprintf("https://%s/admin/config", c.Addr)
 		req, err := http.NewRequest("POST", url, strings.NewReader(batchPayload))
@@ -257,13 +346,16 @@ func HTTPS(c Config) []stats.Result {
 			log.Printf("https batch: HTTP %d", resp.StatusCode)
 			return errDuration
 		}
+		if *batchCC != nil {
+			batchTrips[idx] = (*batchCC).Trips() - before
+		}
 		return time.Since(start)
 	})
 
 	results := []stats.Result{
-		stats.Summarize("https", "fresh-conn", c.Commands, c.Iterations, c.Concurrency, c.Profile, c.RTTms, freshTimes),
-		stats.Summarize("https", "keep-alive", c.Commands, c.Iterations, c.Concurrency, c.Profile, c.RTTms, reuseTimes),
-		stats.Summarize("https", "batch-post", c.Commands, c.Iterations, c.Concurrency, c.Profile, c.RTTms, batchTimes),
+		stats.Summarize("https", "fresh-conn", c.Commands, c.Iterations, c.Concurrency, c.Profile, c.RTTms, freshTimes, freshTrips),
+		stats.Summarize("https", "keep-alive", c.Commands, c.Iterations, c.Concurrency, c.Profile, c.RTTms, reuseTimes, keepTrips),
+		stats.Summarize("https", "batch-post", c.Commands, c.Iterations, c.Concurrency, c.Profile, c.RTTms, batchTimes, batchTrips),
 	}
 
 	// Mode 4: multi-command GET (ASA slash syntax)
@@ -274,13 +366,16 @@ func HTTPS(c Config) []stats.Result {
 		}
 		multiPath := strings.Join(cmdParts, "/")
 
-		multiClient := &http.Client{
-			Transport: &http.Transport{TLSClientConfig: tlsCfg},
-			Timeout:   30 * time.Second,
-		}
-		_ = doHTTPExec(multiClient, c.Addr, c.User, c.Pass) // warmup
+		multiTr, multiCC := countingTransport(false)
+		multiClient := &http.Client{Transport: multiTr, Timeout: 30 * time.Second}
+		_ = doHTTPExec(multiClient, c.Addr, c.User, c.Pass)
 
-		multiTimes := stats.RunParallel(c.Iterations, c.Concurrency, func() time.Duration {
+		multiTrips := make([]int, c.Iterations)
+		multiTimes := stats.RunParallel(c.Iterations, c.Concurrency, func(idx int) time.Duration {
+			var before int
+			if *multiCC != nil {
+				before = (*multiCC).Trips()
+			}
 			start := time.Now()
 			url := fmt.Sprintf("https://%s/admin/exec/%s", c.Addr, multiPath)
 			req, err := http.NewRequest("GET", url, nil)
@@ -299,9 +394,12 @@ func HTTPS(c Config) []stats.Result {
 				log.Printf("https multi: HTTP %d", resp.StatusCode)
 				return errDuration
 			}
+			if *multiCC != nil {
+				multiTrips[idx] = (*multiCC).Trips() - before
+			}
 			return time.Since(start)
 		})
-		results = append(results, stats.Summarize("https", "multi-cmd", c.Commands, c.Iterations, c.Concurrency, c.Profile, c.RTTms, multiTimes))
+		results = append(results, stats.Summarize("https", "multi-cmd", c.Commands, c.Iterations, c.Concurrency, c.Profile, c.RTTms, multiTimes, multiTrips))
 	}
 
 	return results
@@ -321,38 +419,66 @@ func Proxy(c ProxyConfig) []stats.Result {
 	tlsCfg := &tls.Config{InsecureSkipVerify: true}
 	payload := stats.GenerateExecPayload(c.Commands)
 
-	doProxy := func(addr string) time.Duration {
+	doProxy := func(addr string) (time.Duration, int) {
 		start := time.Now()
-		client := &http.Client{
-			Transport: &http.Transport{TLSClientConfig: tlsCfg},
-			Timeout:   30 * time.Second,
+		var cc *rtcount.Conn
+		tr := &http.Transport{
+			TLSClientConfig: tlsCfg,
+			DialTLSContext: func(ctx context.Context, network, a string) (net.Conn, error) {
+				tc, err := net.Dial(network, a)
+				if err != nil {
+					return nil, err
+				}
+				cc = rtcount.Wrap(tc)
+				tlsConn := tls.Client(cc, tlsCfg)
+				if err := tlsConn.HandshakeContext(ctx); err != nil {
+					tc.Close()
+					return nil, err
+				}
+				return tlsConn, nil
+			},
 		}
+		client := &http.Client{Transport: tr, Timeout: 30 * time.Second}
 		url := fmt.Sprintf("https://%s/admin/config", addr)
 		req, err := http.NewRequest("POST", url, strings.NewReader(payload))
 		if err != nil {
-			return errDuration
+			return errDuration, 0
 		}
 		req.SetBasicAuth(c.User, c.Pass)
 		resp, err := client.Do(req)
 		if err != nil {
 			log.Printf("proxy: %v", err)
-			return errDuration
+			return errDuration, 0
 		}
 		_, _ = io.ReadAll(resp.Body)
 		resp.Body.Close()
 		if resp.StatusCode != http.StatusOK {
 			log.Printf("proxy: HTTP %d", resp.StatusCode)
-			return errDuration
+			return errDuration, 0
 		}
-		return time.Since(start)
+		var trips int
+		if cc != nil {
+			trips = cc.Trips()
+		}
+		return time.Since(start), trips
 	}
 
-	freshTimes := stats.RunParallel(c.Iterations, c.Concurrency, func() time.Duration { return doProxy(c.FreshAddr) })
-	pooledTimes := stats.RunParallel(c.Iterations, c.Concurrency, func() time.Duration { return doProxy(c.PooledAddr) })
+	freshTrips := make([]int, c.Iterations)
+	freshTimes := stats.RunParallel(c.Iterations, c.Concurrency, func(idx int) time.Duration {
+		d, t := doProxy(c.FreshAddr)
+		freshTrips[idx] = t
+		return d
+	})
+	pooledTrips := make([]int, c.Iterations)
+	pooledTimes := stats.RunParallel(c.Iterations, c.Concurrency, func(idx int) time.Duration {
+		d, t := doProxy(c.PooledAddr)
+		pooledTrips[idx] = t
+		return d
+	})
 
 	return []stats.Result{
-		stats.Summarize("proxy", "fresh-ssh", c.Commands, c.Iterations, c.Concurrency, c.Profile, c.RTTms, freshTimes),
-		stats.Summarize("proxy", "pooled-ssh", c.Commands, c.Iterations, c.Concurrency, c.Profile, c.RTTms, pooledTimes),
+		stats.Summarize("proxy", "fresh-ssh", c.Commands, c.Iterations, c.Concurrency, c.Profile, c.RTTms, freshTimes, freshTrips),
+		stats.Summarize("proxy", "pooled-ssh", c.Commands, c.Iterations, c.Concurrency, c.Profile, c.RTTms, pooledTimes, pooledTrips),
 	}
 }
 

--- a/internal/bench/http3.go
+++ b/internal/bench/http3.go
@@ -1,10 +1,12 @@
 package bench
 
 import (
+	"context"
 	"crypto/tls"
 	"fmt"
 	"io"
 	"log"
+	"net"
 	"net/http"
 	"strings"
 	"time"
@@ -12,8 +14,27 @@ import (
 	"github.com/quic-go/quic-go"
 	"github.com/quic-go/quic-go/http3"
 
+	"github.com/lykinsbd/clibench/internal/rtcount"
 	"github.com/lykinsbd/clibench/internal/stats"
 )
+
+// h3Dial returns an http3.Transport.Dial function that wraps the UDP conn
+// with rtcount and stores the counter at *pcc.
+func h3Dial(pcc **rtcount.PacketConn) func(ctx context.Context, addr string, tlsCfg *tls.Config, cfg *quic.Config) (*quic.Conn, error) {
+	return func(ctx context.Context, addr string, tlsCfg *tls.Config, cfg *quic.Config) (*quic.Conn, error) {
+		udpAddr, err := net.ResolveUDPAddr("udp", addr)
+		if err != nil {
+			return nil, err
+		}
+		udpConn, err := net.ListenUDP("udp", nil)
+		if err != nil {
+			return nil, err
+		}
+		cc := rtcount.WrapPacket(udpConn)
+		*pcc = cc
+		return quic.Dial(ctx, cc, udpAddr, tlsCfg, cfg)
+	}
+}
 
 // HTTP3 runs all HTTP/3 benchmark modes and returns the results.
 func HTTP3(c Config) []stats.Result {
@@ -22,9 +43,11 @@ func HTTP3(c Config) []stats.Result {
 	tlsCfg := &tls.Config{InsecureSkipVerify: true, NextProtos: []string{http3.NextProtoH3}}
 
 	// Mode 1: fresh connection per iteration
-	freshTimes := stats.RunParallel(c.Iterations, c.Concurrency, func() time.Duration {
+	freshTrips := make([]int, c.Iterations)
+	freshTimes := stats.RunParallel(c.Iterations, c.Concurrency, func(idx int) time.Duration {
 		start := time.Now()
-		tr := &http3.Transport{TLSClientConfig: tlsCfg.Clone()}
+		var cc *rtcount.PacketConn
+		tr := &http3.Transport{TLSClientConfig: tlsCfg.Clone(), Dial: h3Dial(&cc)}
 		client := &http.Client{Transport: tr, Timeout: 30 * time.Second}
 		for i := 0; i < c.Commands; i++ {
 			if err := doHTTPExec(client, c.Addr, c.User, c.Pass); err != nil {
@@ -33,16 +56,25 @@ func HTTP3(c Config) []stats.Result {
 				return errDuration
 			}
 		}
+		if cc != nil {
+			freshTrips[idx] = cc.Trips()
+		}
 		tr.Close()
 		return time.Since(start)
 	})
 
 	// Mode 2: keep-alive (shared QUIC connection)
-	keepTr := &http3.Transport{TLSClientConfig: tlsCfg.Clone()}
+	var keepCC *rtcount.PacketConn
+	keepTr := &http3.Transport{TLSClientConfig: tlsCfg.Clone(), Dial: h3Dial(&keepCC)}
 	keepClient := &http.Client{Transport: keepTr, Timeout: 30 * time.Second}
 	_ = doHTTPExec(keepClient, c.Addr, c.User, c.Pass) // warmup
 
-	keepTimes := stats.RunParallel(c.Iterations, c.Concurrency, func() time.Duration {
+	keepTrips := make([]int, c.Iterations)
+	keepTimes := stats.RunParallel(c.Iterations, c.Concurrency, func(idx int) time.Duration {
+		var before int
+		if keepCC != nil {
+			before = keepCC.Trips()
+		}
 		start := time.Now()
 		for i := 0; i < c.Commands; i++ {
 			if err := doHTTPExec(keepClient, c.Addr, c.User, c.Pass); err != nil {
@@ -50,17 +82,26 @@ func HTTP3(c Config) []stats.Result {
 				return errDuration
 			}
 		}
+		if keepCC != nil {
+			keepTrips[idx] = keepCC.Trips() - before
+		}
 		return time.Since(start)
 	})
 	keepTr.Close()
 
 	// Mode 3: batch POST over shared connection
 	batchPayload := stats.GenerateExecPayload(c.Commands)
-	batchTr := &http3.Transport{TLSClientConfig: tlsCfg.Clone()}
+	var batchCC *rtcount.PacketConn
+	batchTr := &http3.Transport{TLSClientConfig: tlsCfg.Clone(), Dial: h3Dial(&batchCC)}
 	batchClient := &http.Client{Transport: batchTr, Timeout: 30 * time.Second}
 	_ = doHTTPExec(batchClient, c.Addr, c.User, c.Pass) // warmup
 
-	batchTimes := stats.RunParallel(c.Iterations, c.Concurrency, func() time.Duration {
+	batchTrips := make([]int, c.Iterations)
+	batchTimes := stats.RunParallel(c.Iterations, c.Concurrency, func(idx int) time.Duration {
+		var before int
+		if batchCC != nil {
+			before = batchCC.Trips()
+		}
 		start := time.Now()
 		url := fmt.Sprintf("https://%s/admin/config", c.Addr)
 		req, err := http.NewRequest("POST", url, strings.NewReader(batchPayload))
@@ -79,18 +120,20 @@ func HTTP3(c Config) []stats.Result {
 			log.Printf("http3 batch: HTTP %d", resp.StatusCode)
 			return errDuration
 		}
+		if batchCC != nil {
+			batchTrips[idx] = batchCC.Trips() - before
+		}
 		return time.Since(start)
 	})
 	batchTr.Close()
 
 	results := []stats.Result{
-		stats.Summarize("http3", "fresh-conn", c.Commands, c.Iterations, c.Concurrency, c.Profile, c.RTTms, freshTimes),
-		stats.Summarize("http3", "keep-alive", c.Commands, c.Iterations, c.Concurrency, c.Profile, c.RTTms, keepTimes),
-		stats.Summarize("http3", "batch-post", c.Commands, c.Iterations, c.Concurrency, c.Profile, c.RTTms, batchTimes),
+		stats.Summarize("http3", "fresh-conn", c.Commands, c.Iterations, c.Concurrency, c.Profile, c.RTTms, freshTimes, freshTrips),
+		stats.Summarize("http3", "keep-alive", c.Commands, c.Iterations, c.Concurrency, c.Profile, c.RTTms, keepTimes, keepTrips),
+		stats.Summarize("http3", "batch-post", c.Commands, c.Iterations, c.Concurrency, c.Profile, c.RTTms, batchTimes, batchTrips),
 	}
 
 	// Mode 4: 0-RTT resumption
-	// First connection stores the session ticket, second uses it for 0-RTT.
 	sessionCache := tls.NewLRUClientSessionCache(1)
 	zeroRTTCfg := &tls.Config{
 		InsecureSkipVerify: true,
@@ -105,14 +148,16 @@ func HTTP3(c Config) []stats.Result {
 		log.Printf("http3 0rtt warmup: %v", err)
 	}
 	warmTr.Close()
-	// Small pause to ensure session ticket is stored
 	time.Sleep(50 * time.Millisecond)
 
-	zeroTimes := stats.RunParallel(c.Iterations, c.Concurrency, func() time.Duration {
+	zeroTrips := make([]int, c.Iterations)
+	zeroTimes := stats.RunParallel(c.Iterations, c.Concurrency, func(idx int) time.Duration {
 		start := time.Now()
+		var cc *rtcount.PacketConn
 		tr := &http3.Transport{
 			TLSClientConfig: zeroRTTCfg,
 			QUICConfig:      &quic.Config{Allow0RTT: true},
+			Dial:            h3Dial(&cc),
 		}
 		client := &http.Client{Transport: tr, Timeout: 30 * time.Second}
 		for i := 0; i < c.Commands; i++ {
@@ -122,10 +167,13 @@ func HTTP3(c Config) []stats.Result {
 				return errDuration
 			}
 		}
+		if cc != nil {
+			zeroTrips[idx] = cc.Trips()
+		}
 		tr.Close()
 		return time.Since(start)
 	})
-	results = append(results, stats.Summarize("http3", "0rtt-resumption", c.Commands, c.Iterations, c.Concurrency, c.Profile, c.RTTms, zeroTimes))
+	results = append(results, stats.Summarize("http3", "0rtt-resumption", c.Commands, c.Iterations, c.Concurrency, c.Profile, c.RTTms, zeroTimes, zeroTrips))
 
 	return results
 }

--- a/internal/bench/tunnel.go
+++ b/internal/bench/tunnel.go
@@ -22,12 +22,9 @@ func Tunnel(c TunnelConfig) []stats.Result {
 
 	var results []stats.Result
 
-	// HTTPS tunnel modes
 	if c.HTTPSHeadendAddr != "" {
 		results = append(results, tunnelFresh(cfg, c, c.HTTPSHeadendAddr, "tunnel", "ssh-https-ssh")...)
 	}
-
-	// HTTP/3 tunnel modes
 	if c.H3HeadendAddr != "" {
 		results = append(results, tunnelFresh(cfg, c, c.H3HeadendAddr, "tunnel", "ssh-http3-ssh")...)
 	}
@@ -39,9 +36,10 @@ func tunnelFresh(cfg *ssh.ClientConfig, c TunnelConfig, edgeAddr, transport, op 
 	batchPayload := stats.GenerateExecPayload(c.Commands)
 
 	// Mode 1: fresh SSH connection per iteration
-	freshTimes := stats.RunParallel(c.Iterations, c.Concurrency, func() time.Duration {
+	freshTrips := make([]int, c.Iterations)
+	freshTimes := stats.RunParallel(c.Iterations, c.Concurrency, func(idx int) time.Duration {
 		start := time.Now()
-		conn, err := ssh.Dial("tcp", edgeAddr, cfg)
+		conn, cc, err := sshDialCounted(edgeAddr, cfg)
 		if err != nil {
 			log.Printf("%s fresh: %v", op, err)
 			return errDuration
@@ -60,13 +58,15 @@ func tunnelFresh(cfg *ssh.ClientConfig, c TunnelConfig, edgeAddr, transport, op 
 				return errDuration
 			}
 		}
+		freshTrips[idx] = cc.Trips()
 		return time.Since(start)
 	})
 
-	// Mode 2: batch exec (all commands in one SSH exec payload)
-	batchTimes := stats.RunParallel(c.Iterations, c.Concurrency, func() time.Duration {
+	// Mode 2: batch exec
+	batchTrips := make([]int, c.Iterations)
+	batchTimes := stats.RunParallel(c.Iterations, c.Concurrency, func(idx int) time.Duration {
 		start := time.Now()
-		conn, err := ssh.Dial("tcp", edgeAddr, cfg)
+		conn, cc, err := sshDialCounted(edgeAddr, cfg)
 		if err != nil {
 			log.Printf("%s-batch: %v", op, err)
 			return errDuration
@@ -83,11 +83,12 @@ func tunnelFresh(cfg *ssh.ClientConfig, c TunnelConfig, edgeAddr, transport, op 
 			log.Printf("%s-batch exec: %v", op, err)
 			return errDuration
 		}
+		batchTrips[idx] = cc.Trips()
 		return time.Since(start)
 	})
 
 	return []stats.Result{
-		stats.Summarize(transport, op, c.Commands, c.Iterations, c.Concurrency, c.Profile, c.RTTms, freshTimes),
-		stats.Summarize(transport, op+"-batch", c.Commands, c.Iterations, c.Concurrency, c.Profile, c.RTTms, batchTimes),
+		stats.Summarize(transport, op, c.Commands, c.Iterations, c.Concurrency, c.Profile, c.RTTms, freshTimes, freshTrips),
+		stats.Summarize(transport, op+"-batch", c.Commands, c.Iterations, c.Concurrency, c.Profile, c.RTTms, batchTimes, batchTrips),
 	}
 }

--- a/internal/rtcount/rtcount.go
+++ b/internal/rtcount/rtcount.go
@@ -1,0 +1,68 @@
+// Package rtcount provides a net.Conn wrapper that counts application-level
+// round trips by tracking I/O direction changes. A direction change from
+// write to read (or read to write) indicates a round trip — the client
+// sent data and is now waiting for a response.
+package rtcount
+
+import (
+	"net"
+	"sync/atomic"
+)
+
+// Conn wraps a net.Conn and counts direction changes.
+type Conn struct {
+	net.Conn
+	trips   atomic.Int64
+	lastDir atomic.Int32 // 0=none, 1=read, 2=write
+}
+
+// Wrap returns a Conn that counts round trips on c.
+func Wrap(c net.Conn) *Conn {
+	return &Conn{Conn: c}
+}
+
+func (c *Conn) Read(b []byte) (int, error) {
+	if c.lastDir.Swap(1) == 2 {
+		c.trips.Add(1)
+	}
+	return c.Conn.Read(b)
+}
+
+func (c *Conn) Write(b []byte) (int, error) {
+	c.lastDir.Store(2)
+	return c.Conn.Write(b)
+}
+
+// Trips returns the number of observed round trips.
+func (c *Conn) Trips() int {
+	return int(c.trips.Load())
+}
+
+// PacketConn wraps a net.PacketConn and counts direction changes.
+type PacketConn struct {
+	net.PacketConn
+	trips   atomic.Int64
+	lastDir atomic.Int32
+}
+
+// WrapPacket returns a PacketConn that counts round trips on pc.
+func WrapPacket(pc net.PacketConn) *PacketConn {
+	return &PacketConn{PacketConn: pc}
+}
+
+func (c *PacketConn) ReadFrom(b []byte) (int, net.Addr, error) {
+	if c.lastDir.Swap(1) == 2 {
+		c.trips.Add(1)
+	}
+	return c.PacketConn.ReadFrom(b)
+}
+
+func (c *PacketConn) WriteTo(b []byte, addr net.Addr) (int, error) {
+	c.lastDir.Store(2)
+	return c.PacketConn.WriteTo(b, addr)
+}
+
+// Trips returns the number of observed round trips.
+func (c *PacketConn) Trips() int {
+	return int(c.trips.Load())
+}

--- a/internal/rtcount/rtcount_test.go
+++ b/internal/rtcount/rtcount_test.go
@@ -1,0 +1,98 @@
+package rtcount
+
+import (
+	"net"
+	"testing"
+)
+
+func TestConnTrips(t *testing.T) {
+	s, c := net.Pipe()
+	defer s.Close()
+	defer c.Close()
+
+	cc := Wrap(c)
+
+	// Write then read = 1 trip
+	go func() {
+		buf := make([]byte, 5)
+		_, _ = s.Read(buf)
+		_, _ = s.Write([]byte("world"))
+	}()
+
+	_, _ = cc.Write([]byte("hello"))
+	buf := make([]byte, 5)
+	_, _ = cc.Read(buf)
+
+	if got := cc.Trips(); got != 1 {
+		t.Errorf("Trips() = %d, want 1", got)
+	}
+
+	// Another write→read = 2 total
+	go func() {
+		buf := make([]byte, 4)
+		_, _ = s.Read(buf)
+		_, _ = s.Write([]byte("back"))
+	}()
+
+	_, _ = cc.Write([]byte("ping"))
+	_, _ = cc.Read(buf[:4])
+
+	if got := cc.Trips(); got != 2 {
+		t.Errorf("Trips() = %d, want 2", got)
+	}
+}
+
+func TestConnConsecutiveWritesCountOnce(t *testing.T) {
+	s, c := net.Pipe()
+	defer s.Close()
+	defer c.Close()
+
+	cc := Wrap(c)
+
+	go func() {
+		buf := make([]byte, 10)
+		_, _ = s.Read(buf)
+		_, _ = s.Read(buf)
+		_, _ = s.Write([]byte("ok"))
+	}()
+
+	// Two consecutive writes should not increment trips
+	_, _ = cc.Write([]byte("a"))
+	_, _ = cc.Write([]byte("b"))
+	buf := make([]byte, 2)
+	_, _ = cc.Read(buf)
+
+	if got := cc.Trips(); got != 1 {
+		t.Errorf("Trips() = %d, want 1 (consecutive writes should count as one direction)", got)
+	}
+}
+
+func TestPacketConnTrips(t *testing.T) {
+	a, err := net.ListenPacket("udp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer a.Close()
+	b, err := net.ListenPacket("udp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer b.Close()
+
+	cc := WrapPacket(a)
+
+	// Write to b, then read response
+	go func() {
+		buf := make([]byte, 64)
+		n, addr, _ := b.ReadFrom(buf)
+		_, _ = b.WriteTo(buf[:n], addr)
+	}()
+
+	_, _ = cc.WriteTo([]byte("ping"), b.LocalAddr())
+	buf := make([]byte, 64)
+	_, _, _ = cc.ReadFrom(buf)
+
+	if got := cc.Trips(); got != 1 {
+		t.Errorf("Trips() = %d, want 1", got)
+	}
+}

--- a/internal/stats/stats.go
+++ b/internal/stats/stats.go
@@ -24,6 +24,7 @@ type Result struct {
 	Concurrency int     `json:"concurrency"`
 	Latency     string  `json:"latency_profile"`
 	RTTms       float64 `json:"simulated_rtt_ms"`
+	RoundTrips  int     `json:"round_trips,omitempty"`
 	AvgMs       float64 `json:"avg_ms"`
 	MinMs       float64 `json:"min_ms"`
 	MaxMs       float64 `json:"max_ms"`
@@ -33,7 +34,9 @@ type Result struct {
 }
 
 // Summarize computes statistics from a slice of durations.
-func Summarize(transport, op string, cmds, iterations, concurrency int, profile string, rttMs float64, times []time.Duration) Result {
+// An optional trips slice provides per-iteration round-trip counts;
+// the median value is stored in the result.
+func Summarize(transport, op string, cmds, iterations, concurrency int, profile string, rttMs float64, times []time.Duration, trips ...[]int) Result {
 	valid := make([]float64, 0, len(times))
 	errors := 0
 	for _, t := range times {
@@ -82,6 +85,7 @@ func Summarize(transport, op string, cmds, iterations, concurrency int, profile 
 		Concurrency: concurrency,
 		Latency:     profile,
 		RTTms:       rttMs,
+		RoundTrips:  medianTrips(trips),
 		AvgMs:       avg,
 		MinMs:       valid[0],
 		MaxMs:       valid[n-1],
@@ -89,6 +93,17 @@ func Summarize(transport, op string, cmds, iterations, concurrency int, profile 
 		P95Ms:       Percentile(valid, 95),
 		StddevMs:    stddev,
 	}
+}
+
+// medianTrips returns the median of the first trips slice, or 0 if empty.
+func medianTrips(trips [][]int) int {
+	if len(trips) == 0 || len(trips[0]) == 0 {
+		return 0
+	}
+	s := make([]int, len(trips[0]))
+	copy(s, trips[0])
+	sort.Ints(s)
+	return s[len(s)/2]
 }
 
 // Percentile returns the p-th percentile from a sorted slice.
@@ -107,7 +122,8 @@ func Percentile(sorted []float64, p float64) float64 {
 }
 
 // RunParallel executes fn iterations times with the given concurrency.
-func RunParallel(iterations, concurrency int, fn func() time.Duration) []time.Duration {
+// The function receives the iteration index for per-iteration data collection.
+func RunParallel(iterations, concurrency int, fn func(idx int) time.Duration) []time.Duration {
 	results := make([]time.Duration, iterations)
 	sem := make(chan struct{}, concurrency)
 	var wg sync.WaitGroup
@@ -118,7 +134,7 @@ func RunParallel(iterations, concurrency int, fn func() time.Duration) []time.Du
 		go func(idx int) {
 			defer wg.Done()
 			defer func() { <-sem }()
-			results[idx] = fn()
+			results[idx] = fn(idx)
 		}(i)
 	}
 	wg.Wait()

--- a/internal/stats/stats_test.go
+++ b/internal/stats/stats_test.go
@@ -129,7 +129,7 @@ func TestRunParallelConcurrency(t *testing.T) {
 	// With concurrency=1, iterations should execute serially (no overlap)
 	var running atomic.Int32
 	var maxRunning atomic.Int32
-	results := RunParallel(5, 1, func() time.Duration {
+	results := RunParallel(5, 1, func(_ int) time.Duration {
 		cur := running.Add(1)
 		for {
 			old := maxRunning.Load()
@@ -150,7 +150,7 @@ func TestRunParallelConcurrency(t *testing.T) {
 }
 
 func TestRunParallelCountsErrors(t *testing.T) {
-	results := RunParallel(4, 1, func() time.Duration {
+	results := RunParallel(4, 1, func(_ int) time.Duration {
 		return ErrDuration
 	})
 	errCount := 0
@@ -161,5 +161,22 @@ func TestRunParallelCountsErrors(t *testing.T) {
 	}
 	if errCount != 4 {
 		t.Errorf("errCount = %d, want 4", errCount)
+	}
+}
+
+func TestSummarizeWithTrips(t *testing.T) {
+	times := []time.Duration{10 * time.Millisecond, 20 * time.Millisecond, 15 * time.Millisecond}
+	trips := []int{5, 7, 5}
+	r := Summarize("ssh", "fresh-conn", 1, 3, 1, "local", 0, times, trips)
+	if r.RoundTrips != 5 { // median of [5, 5, 7] = 5
+		t.Errorf("RoundTrips = %d, want 5", r.RoundTrips)
+	}
+}
+
+func TestSummarizeWithoutTrips(t *testing.T) {
+	times := []time.Duration{10 * time.Millisecond}
+	r := Summarize("https", "keep-alive", 1, 1, 1, "local", 0, times)
+	if r.RoundTrips != 0 {
+		t.Errorf("RoundTrips = %d, want 0 when no trips provided", r.RoundTrips)
 	}
 }


### PR DESCRIPTION
Closes #12

## What

Instruments every benchmark connection to count actual round trips (write→read direction changes) on the wire. No guessing — these are measured from real I/O.

## How

New `internal/rtcount` package provides `Conn` (TCP) and `PacketConn` (UDP) wrappers that use atomic counters to track direction changes. Each write→read transition = 1 round trip.

Wiring per transport:
- **SSH**: replaced `ssh.Dial` with `net.Dial` + `rtcount.Wrap` + `ssh.NewClientConn`
- **HTTPS**: wrap TCP conn *before* TLS via `DialTLSContext` (captures TLS handshake RTs)
- **HTTP/3**: wrap UDP conn via `http3.Transport.Dial` hook with `rtcount.WrapPacket`
- **Proxy**: same `DialTLSContext` pattern
- **Tunnel**: uses `sshDialCounted` helper

Median RT count per mode stored in `stats.Result.RoundTrips`, displayed in all output formats.

## Sample output (2 commands, local)

```
TRANSPORT  OPERATION        CMDS  ITER  RT  AVG(ms)
ssh        fresh-conn       2     3     11  4.81
ssh        reuse-conn       2     3     5   0.68
ssh        batch-exec       2     3     10  3.84
https      fresh-conn       2     3     4   6.27
https      keep-alive       2     3     2   0.46
https      batch-post       2     3     1   0.23
http3      fresh-conn       2     3     4   5.92
http3      keep-alive       2     3     3   1.05
http3      batch-post       2     3     1   0.85
```

SSH fresh-conn needs 11 round trips vs HTTPS's 4 for the same 2 commands — measured, not theoretical.

## Changes

- New: `internal/rtcount/` — Conn and PacketConn wrappers (3 tests)
- Modified: `internal/stats/` — `Result.RoundTrips` field, `Summarize` accepts trips, `RunParallel` passes index (2 new tests)
- Modified: `internal/bench/` — all 5 benchmark functions instrumented
- Modified: `cmd/clibench/format.go` — RT column in table and CSV

## Testing

- 3 rtcount unit tests (Conn trips, consecutive writes, PacketConn trips)
- 2 stats tests (Summarize with/without trips)
- All existing tests updated for `RunParallel(iterations, concurrency, func(idx int))` signature
- Full suite passes with `-race`