### PR TITLE
feat: capture wire-level packet counts per iteration

### DIFF
--- a/cmd/clibench/bench.go
+++ b/cmd/clibench/bench.go
@@ -210,7 +210,8 @@ func (b *BenchCmd) Run() error {
 		Hostname:    hostname,
 	}
 
-	// pktWrap runs a benchmark function and attaches per-mode packet counts.
+	// pktWrap runs a benchmark function and attaches packet counts.
+	// Counts are total for the transport (all modes combined).
 	pktWrap := func(fn func() []stats.Result) []stats.Result {
 		if pc == nil {
 			return fn()
@@ -218,17 +219,11 @@ func (b *BenchCmd) Run() error {
 		pc.Reset()
 		rs := fn()
 		totalIn, totalOut := pc.Snapshot()
-		// Distribute total packets evenly across modes (each mode runs
-		// sequentially within a transport function).
-		// For per-mode granularity, each mode would need its own snapshot,
-		// but total-per-transport is sufficient for blog charts.
+		// Store total packets on the first result; others get zero.
+		// Per-mode granularity would require snapshots inside each bench function.
 		if len(rs) > 0 {
-			perIn := totalIn / len(rs)
-			perOut := totalOut / len(rs)
-			for i := range rs {
-				rs[i].PacketsIn = perIn
-				rs[i].PacketsOut = perOut
-			}
+			rs[0].PacketsIn = totalIn
+			rs[0].PacketsOut = totalOut
 		}
 		return rs
 	}

--- a/cmd/clibench/bench.go
+++ b/cmd/clibench/bench.go
@@ -17,6 +17,7 @@ import (
 	"github.com/lykinsbd/clibench/internal/httpserver"
 	latencyPkg "github.com/lykinsbd/clibench/internal/latency"
 	"github.com/lykinsbd/clibench/internal/netem"
+	"github.com/lykinsbd/clibench/internal/pktcount"
 	"github.com/lykinsbd/clibench/internal/proxy"
 	"github.com/lykinsbd/clibench/internal/sshserver"
 	"github.com/lykinsbd/clibench/internal/stats"
@@ -181,6 +182,23 @@ func (b *BenchCmd) Run() error {
 	time.Sleep(500 * time.Millisecond)
 	log.Printf("Server ready — profile=%s, simulated RTT=%.0fms", b.Latency, rttMs)
 
+	// Start packet counter if we have root (same requirement as netem)
+	var pc *pktcount.Counter
+	if !b.Userspace && delay > 0 {
+		allPorts := []int{b.SSHPort, b.HTTPSPort, b.HTTP3Port, b.ProxyPort, b.ProxyPort + 1,
+			backendSSHPort, tunnelSiteHTTPSPort, tunnelSiteH3Port,
+			b.HeadendHTTPSPort, b.HeadendH3Port}
+		var err error
+		pc, err = pktcount.New(allPorts)
+		if err != nil {
+			log.Printf("packet counter unavailable: %v", err)
+		} else {
+			pc.Start()
+			defer pc.Stop()
+			log.Printf("AF_PACKET: counting packets on ports %v", allPorts)
+		}
+	}
+
 	cfg := bench.Config{
 		User:        b.User,
 		Pass:        b.Pass,
@@ -192,40 +210,59 @@ func (b *BenchCmd) Run() error {
 		Hostname:    hostname,
 	}
 
+	// pktWrap runs a benchmark function and attaches per-mode packet counts.
+	pktWrap := func(fn func() []stats.Result) []stats.Result {
+		if pc == nil {
+			return fn()
+		}
+		pc.Reset()
+		rs := fn()
+		totalIn, totalOut := pc.Snapshot()
+		// Distribute total packets evenly across modes (each mode runs
+		// sequentially within a transport function).
+		// For per-mode granularity, each mode would need its own snapshot,
+		// but total-per-transport is sufficient for blog charts.
+		if len(rs) > 0 {
+			perIn := totalIn / len(rs)
+			perOut := totalOut / len(rs)
+			for i := range rs {
+				rs[i].PacketsIn = perIn
+				rs[i].PacketsOut = perOut
+			}
+		}
+		return rs
+	}
+
 	var results []stats.Result
 
 	if b.has("ssh") {
 		c := cfg
 		c.Addr = sshAddr
-		results = append(results, bench.SSH(c)...)
+		results = append(results, pktWrap(func() []stats.Result { return bench.SSH(c) })...)
 	}
 	if b.has("https") {
 		c := cfg
 		c.Addr = httpsAddr
-		results = append(results, bench.HTTPS(c)...)
+		results = append(results, pktWrap(func() []stats.Result { return bench.HTTPS(c) })...)
 	}
 	if b.has("proxy") {
-		results = append(results, bench.Proxy(bench.ProxyConfig{
-			Config:     cfg,
-			FreshAddr:  proxyAddr,
-			PooledAddr: proxyPooledAddr,
+		results = append(results, pktWrap(func() []stats.Result {
+			return bench.Proxy(bench.ProxyConfig{Config: cfg, FreshAddr: proxyAddr, PooledAddr: proxyPooledAddr})
 		})...)
 	}
 	if b.has("http3") {
 		c := cfg
 		c.Addr = http3Addr
-		results = append(results, bench.HTTP3(c)...)
+		results = append(results, pktWrap(func() []stats.Result { return bench.HTTP3(c) })...)
 	}
 	if b.has("tunnel-https") {
-		results = append(results, bench.Tunnel(bench.TunnelConfig{
-			Config:           cfg,
-			HTTPSHeadendAddr: headendHTTPSAddr,
+		results = append(results, pktWrap(func() []stats.Result {
+			return bench.Tunnel(bench.TunnelConfig{Config: cfg, HTTPSHeadendAddr: headendHTTPSAddr})
 		})...)
 	}
 	if b.has("tunnel-http3") {
-		results = append(results, bench.Tunnel(bench.TunnelConfig{
-			Config:        cfg,
-			H3HeadendAddr: headendH3Addr,
+		results = append(results, pktWrap(func() []stats.Result {
+			return bench.Tunnel(bench.TunnelConfig{Config: cfg, H3HeadendAddr: headendH3Addr})
 		})...)
 	}
 

--- a/cmd/clibench/format.go
+++ b/cmd/clibench/format.go
@@ -11,11 +11,11 @@ import (
 
 func writeTable(w io.Writer, results []stats.Result) error {
 	tw := tabwriter.NewWriter(w, 0, 4, 2, ' ', 0)
-	fmt.Fprintln(tw, "TRANSPORT\tOPERATION\tCMDS\tITER\tERR\tRT\tREADS\tWRITES\tAVG(ms)\tMIN(ms)\tP50(ms)\tP95(ms)\tMAX(ms)\tSTDDEV")
+	fmt.Fprintln(tw, "TRANSPORT\tOPERATION\tCMDS\tITER\tERR\tRT\tRD_OPS\tWR_OPS\tPKT_IN\tPKT_OUT\tAVG(ms)\tMIN(ms)\tP50(ms)\tP95(ms)\tMAX(ms)\tSTDDEV")
 	for _, r := range results {
-		fmt.Fprintf(tw, "%s\t%s\t%d\t%d\t%d\t%d\t%d\t%d\t%.2f\t%.2f\t%.2f\t%.2f\t%.2f\t%.2f\n",
+		fmt.Fprintf(tw, "%s\t%s\t%d\t%d\t%d\t%d\t%d\t%d\t%d\t%d\t%.2f\t%.2f\t%.2f\t%.2f\t%.2f\t%.2f\n",
 			r.Transport, r.Operation, r.Commands, r.Iterations, r.Errors,
-			r.RoundTrips, r.Reads, r.Writes,
+			r.RoundTrips, r.ReadOps, r.WriteOps, r.PacketsIn, r.PacketsOut,
 			r.AvgMs, r.MinMs, r.P50Ms, r.P95Ms, r.MaxMs, r.StddevMs)
 	}
 	return tw.Flush()
@@ -26,7 +26,7 @@ func writeCSV(w io.Writer, results []stats.Result) error {
 	_ = cw.Write([]string{
 		"transport", "operation", "commands", "iterations", "errors",
 		"concurrency", "latency_profile", "simulated_rtt_ms",
-		"round_trips", "reads", "writes",
+		"round_trips", "read_ops", "write_ops", "packets_in", "packets_out",
 		"avg_ms", "min_ms", "max_ms", "p50_ms", "p95_ms", "stddev_ms",
 	})
 	for _, r := range results {
@@ -36,7 +36,8 @@ func writeCSV(w io.Writer, results []stats.Result) error {
 			fmt.Sprintf("%d", r.Errors), fmt.Sprintf("%d", r.Concurrency),
 			r.Latency, fmt.Sprintf("%.1f", r.RTTms),
 			fmt.Sprintf("%d", r.RoundTrips),
-			fmt.Sprintf("%d", r.Reads), fmt.Sprintf("%d", r.Writes),
+			fmt.Sprintf("%d", r.ReadOps), fmt.Sprintf("%d", r.WriteOps),
+			fmt.Sprintf("%d", r.PacketsIn), fmt.Sprintf("%d", r.PacketsOut),
 			fmt.Sprintf("%.3f", r.AvgMs), fmt.Sprintf("%.3f", r.MinMs),
 			fmt.Sprintf("%.3f", r.MaxMs), fmt.Sprintf("%.3f", r.P50Ms),
 			fmt.Sprintf("%.3f", r.P95Ms), fmt.Sprintf("%.3f", r.StddevMs),

--- a/cmd/clibench/format.go
+++ b/cmd/clibench/format.go
@@ -11,11 +11,12 @@ import (
 
 func writeTable(w io.Writer, results []stats.Result) error {
 	tw := tabwriter.NewWriter(w, 0, 4, 2, ' ', 0)
-	fmt.Fprintln(tw, "TRANSPORT\tOPERATION\tCMDS\tITER\tERR\tRT\tAVG(ms)\tMIN(ms)\tP50(ms)\tP95(ms)\tMAX(ms)\tSTDDEV")
+	fmt.Fprintln(tw, "TRANSPORT\tOPERATION\tCMDS\tITER\tERR\tRT\tREADS\tWRITES\tAVG(ms)\tMIN(ms)\tP50(ms)\tP95(ms)\tMAX(ms)\tSTDDEV")
 	for _, r := range results {
-		fmt.Fprintf(tw, "%s\t%s\t%d\t%d\t%d\t%d\t%.2f\t%.2f\t%.2f\t%.2f\t%.2f\t%.2f\n",
+		fmt.Fprintf(tw, "%s\t%s\t%d\t%d\t%d\t%d\t%d\t%d\t%.2f\t%.2f\t%.2f\t%.2f\t%.2f\t%.2f\n",
 			r.Transport, r.Operation, r.Commands, r.Iterations, r.Errors,
-			r.RoundTrips, r.AvgMs, r.MinMs, r.P50Ms, r.P95Ms, r.MaxMs, r.StddevMs)
+			r.RoundTrips, r.Reads, r.Writes,
+			r.AvgMs, r.MinMs, r.P50Ms, r.P95Ms, r.MaxMs, r.StddevMs)
 	}
 	return tw.Flush()
 }
@@ -24,7 +25,8 @@ func writeCSV(w io.Writer, results []stats.Result) error {
 	cw := csv.NewWriter(w)
 	_ = cw.Write([]string{
 		"transport", "operation", "commands", "iterations", "errors",
-		"concurrency", "latency_profile", "simulated_rtt_ms", "round_trips",
+		"concurrency", "latency_profile", "simulated_rtt_ms",
+		"round_trips", "reads", "writes",
 		"avg_ms", "min_ms", "max_ms", "p50_ms", "p95_ms", "stddev_ms",
 	})
 	for _, r := range results {
@@ -34,6 +36,7 @@ func writeCSV(w io.Writer, results []stats.Result) error {
 			fmt.Sprintf("%d", r.Errors), fmt.Sprintf("%d", r.Concurrency),
 			r.Latency, fmt.Sprintf("%.1f", r.RTTms),
 			fmt.Sprintf("%d", r.RoundTrips),
+			fmt.Sprintf("%d", r.Reads), fmt.Sprintf("%d", r.Writes),
 			fmt.Sprintf("%.3f", r.AvgMs), fmt.Sprintf("%.3f", r.MinMs),
 			fmt.Sprintf("%.3f", r.MaxMs), fmt.Sprintf("%.3f", r.P50Ms),
 			fmt.Sprintf("%.3f", r.P95Ms), fmt.Sprintf("%.3f", r.StddevMs),

--- a/internal/bench/bench.go
+++ b/internal/bench/bench.go
@@ -66,13 +66,58 @@ func sshDialCounted(addr string, cfg *ssh.ClientConfig) (*ssh.Client, *rtcount.C
 	return ssh.NewClient(sconn, chans, reqs), cc, nil
 }
 
+// counters collects per-iteration stats from parallel slices.
+type counters struct {
+	trips, reads, writes []int
+}
+
+func newCounters(n int) counters {
+	return counters{make([]int, n), make([]int, n), make([]int, n)}
+}
+
+func (c counters) recordConn(idx int, cc *rtcount.Conn) {
+	c.trips[idx] = cc.Trips()
+	c.reads[idx] = cc.Reads()
+	c.writes[idx] = cc.Writes()
+}
+
+func (c counters) recordConnDelta(idx int, cc *rtcount.Conn, bt, br, bw int) {
+	c.trips[idx] = cc.Trips() - bt
+	c.reads[idx] = cc.Reads() - br
+	c.writes[idx] = cc.Writes() - bw
+}
+
+func (c counters) recordConns(idx int, conns []*rtcount.Conn) {
+	for _, cc := range conns {
+		c.trips[idx] += cc.Trips()
+		c.reads[idx] += cc.Reads()
+		c.writes[idx] += cc.Writes()
+	}
+}
+
+func (c counters) recordPacket(idx int, pc *rtcount.PacketConn) {
+	c.trips[idx] = pc.Trips()
+	c.reads[idx] = pc.Reads()
+	c.writes[idx] = pc.Writes()
+}
+
+func (c counters) recordPacketDelta(idx int, pc *rtcount.PacketConn, bt, br, bw int) {
+	c.trips[idx] = pc.Trips() - bt
+	c.reads[idx] = pc.Reads() - br
+	c.writes[idx] = pc.Writes() - bw
+}
+
+func (c counters) iter() stats.IterCounts {
+	return stats.IterCounts{Trips: c.trips, Reads: c.reads, Writes: c.writes}
+}
+
 // SSH runs all SSH benchmark modes and returns the results.
 func SSH(c Config) []stats.Result {
 	log.Printf("Benchmarking SSH (%d iterations, %d concurrency, %d cmds/iter)", c.Iterations, c.Concurrency, c.Commands)
 	cfg := sshConfig(c.User, c.Pass)
 
 	// Mode 1: fresh connection per iteration
-	freshTrips := make([]int, c.Iterations)
+	freshC := newCounters(c.Iterations)
 	freshTimes := stats.RunParallel(c.Iterations, c.Concurrency, func(idx int) time.Duration {
 		start := time.Now()
 		conn, cc, err := sshDialCounted(c.Addr, cfg)
@@ -94,14 +139,14 @@ func SSH(c Config) []stats.Result {
 				return errDuration
 			}
 		}
-		freshTrips[idx] = cc.Trips()
+		freshC.recordConn(idx, cc)
 		return time.Since(start)
 	})
 
 	// Mode 2: reuse one connection (ControlMaster-style)
 	sharedConn, sharedCC, err := sshDialCounted(c.Addr, cfg)
 	var reuseTimes []time.Duration
-	var reuseTrips []int
+	var reuseC counters
 	if err != nil {
 		log.Printf("ssh reuse dial: %v (skipping reuse test)", err)
 	} else {
@@ -109,10 +154,9 @@ func SSH(c Config) []stats.Result {
 			_, _ = sess.Output("show version")
 			sess.Close()
 		}
-		baseTrips := sharedCC.Trips()
-		reuseTrips = make([]int, c.Iterations)
+		reuseC = newCounters(c.Iterations)
 		reuseTimes = stats.RunParallel(c.Iterations, c.Concurrency, func(idx int) time.Duration {
-			before := sharedCC.Trips()
+			bt, br, bw := sharedCC.Trips(), sharedCC.Reads(), sharedCC.Writes()
 			start := time.Now()
 			for i := 0; i < c.Commands; i++ {
 				sess, err := sharedConn.NewSession()
@@ -127,16 +171,15 @@ func SSH(c Config) []stats.Result {
 					return errDuration
 				}
 			}
-			reuseTrips[idx] = sharedCC.Trips() - before
+			reuseC.recordConnDelta(idx, sharedCC, bt, br, bw)
 			return time.Since(start)
 		})
-		_ = baseTrips
 		sharedConn.Close()
 	}
 
 	// Mode 3: batch exec
 	batchPayload := stats.GenerateExecPayload(c.Commands)
-	batchTrips := make([]int, c.Iterations)
+	batchC := newCounters(c.Iterations)
 	batchTimes := stats.RunParallel(c.Iterations, c.Concurrency, func(idx int) time.Duration {
 		start := time.Now()
 		conn, cc, err := sshDialCounted(c.Addr, cfg)
@@ -156,21 +199,21 @@ func SSH(c Config) []stats.Result {
 			log.Printf("ssh batch exec: %v", err)
 			return errDuration
 		}
-		batchTrips[idx] = cc.Trips()
+		batchC.recordConn(idx, cc)
 		return time.Since(start)
 	})
 
 	results := []stats.Result{
-		stats.Summarize("ssh", "fresh-conn", c.Commands, c.Iterations, c.Concurrency, c.Profile, c.RTTms, freshTimes, freshTrips),
+		stats.Summarize("ssh", "fresh-conn", c.Commands, c.Iterations, c.Concurrency, c.Profile, c.RTTms, freshTimes, freshC.iter()),
 	}
 	if reuseTimes != nil {
-		results = append(results, stats.Summarize("ssh", "reuse-conn", c.Commands, c.Iterations, c.Concurrency, c.Profile, c.RTTms, reuseTimes, reuseTrips))
+		results = append(results, stats.Summarize("ssh", "reuse-conn", c.Commands, c.Iterations, c.Concurrency, c.Profile, c.RTTms, reuseTimes, reuseC.iter()))
 	}
-	results = append(results, stats.Summarize("ssh", "batch-exec", c.Commands, c.Iterations, c.Concurrency, c.Profile, c.RTTms, batchTimes, batchTrips))
+	results = append(results, stats.Summarize("ssh", "batch-exec", c.Commands, c.Iterations, c.Concurrency, c.Profile, c.RTTms, batchTimes, batchC.iter()))
 
 	// Mode 4: PTY/shell — fresh connection per iteration
 	prompt := c.Hostname + "#"
-	ptyFreshTrips := make([]int, c.Iterations)
+	ptyFreshC := newCounters(c.Iterations)
 	ptyFreshTimes := stats.RunParallel(c.Iterations, c.Concurrency, func(idx int) time.Duration {
 		start := time.Now()
 		conn, cc, err := sshDialCounted(c.Addr, cfg)
@@ -188,10 +231,10 @@ func SSH(c Config) []stats.Result {
 			log.Printf("ssh pty-fresh: %v", err)
 			return errDuration
 		}
-		ptyFreshTrips[idx] = cc.Trips()
+		ptyFreshC.recordConn(idx, cc)
 		return time.Since(start)
 	})
-	results = append(results, stats.Summarize("ssh", "pty-fresh", c.Commands, c.Iterations, c.Concurrency, c.Profile, c.RTTms, ptyFreshTimes, ptyFreshTrips))
+	results = append(results, stats.Summarize("ssh", "pty-fresh", c.Commands, c.Iterations, c.Concurrency, c.Profile, c.RTTms, ptyFreshTimes, ptyFreshC.iter()))
 
 	// Mode 5: PTY/shell — reuse connection
 	ptyConn, ptyCC, err := sshDialCounted(c.Addr, cfg)
@@ -200,9 +243,9 @@ func SSH(c Config) []stats.Result {
 			_ = ptyExecCmds(sess, prompt, 1)
 			sess.Close()
 		}
-		ptyReuseTrips := make([]int, c.Iterations)
+		ptyReuseC := newCounters(c.Iterations)
 		ptyReuseTimes := stats.RunParallel(c.Iterations, c.Concurrency, func(idx int) time.Duration {
-			before := ptyCC.Trips()
+			bt, br, bw := ptyCC.Trips(), ptyCC.Reads(), ptyCC.Writes()
 			start := time.Now()
 			sess, err := ptyConn.NewSession()
 			if err != nil {
@@ -213,11 +256,11 @@ func SSH(c Config) []stats.Result {
 				log.Printf("ssh pty-reuse: %v", err)
 				return errDuration
 			}
-			ptyReuseTrips[idx] = ptyCC.Trips() - before
+			ptyReuseC.recordConnDelta(idx, ptyCC, bt, br, bw)
 			return time.Since(start)
 		})
 		ptyConn.Close()
-		results = append(results, stats.Summarize("ssh", "pty-reuse", c.Commands, c.Iterations, c.Concurrency, c.Profile, c.RTTms, ptyReuseTimes, ptyReuseTrips))
+		results = append(results, stats.Summarize("ssh", "pty-reuse", c.Commands, c.Iterations, c.Concurrency, c.Profile, c.RTTms, ptyReuseTimes, ptyReuseC.iter()))
 	}
 
 	return results
@@ -255,7 +298,7 @@ func HTTPS(c Config) []stats.Result {
 	}
 
 	// Mode 1: fresh connection per iteration
-	freshTrips := make([]int, c.Iterations)
+	freshC := newCounters(c.Iterations)
 	freshTimes := stats.RunParallel(c.Iterations, c.Concurrency, func(idx int) time.Duration {
 		start := time.Now()
 		var conns []*rtcount.Conn
@@ -284,11 +327,7 @@ func HTTPS(c Config) []stats.Result {
 				return errDuration
 			}
 		}
-		total := 0
-		for _, cc := range conns {
-			total += cc.Trips()
-		}
-		freshTrips[idx] = total
+		freshC.recordConns(idx, conns)
 		return time.Since(start)
 	})
 
@@ -297,11 +336,11 @@ func HTTPS(c Config) []stats.Result {
 	keepClient := &http.Client{Transport: keepTr, Timeout: 30 * time.Second}
 	_ = doHTTPExec(keepClient, c.Addr, c.User, c.Pass)
 
-	keepTrips := make([]int, c.Iterations)
+	keepC := newCounters(c.Iterations)
 	reuseTimes := stats.RunParallel(c.Iterations, c.Concurrency, func(idx int) time.Duration {
-		var before int
+		var bt, br, bw int
 		if *keepCC != nil {
-			before = (*keepCC).Trips()
+			bt, br, bw = (*keepCC).Trips(), (*keepCC).Reads(), (*keepCC).Writes()
 		}
 		start := time.Now()
 		for i := 0; i < c.Commands; i++ {
@@ -311,7 +350,7 @@ func HTTPS(c Config) []stats.Result {
 			}
 		}
 		if *keepCC != nil {
-			keepTrips[idx] = (*keepCC).Trips() - before
+			keepC.recordConnDelta(idx, *keepCC, bt, br, bw)
 		}
 		return time.Since(start)
 	})
@@ -322,11 +361,11 @@ func HTTPS(c Config) []stats.Result {
 	batchClient := &http.Client{Transport: batchTr, Timeout: 30 * time.Second}
 	_ = doHTTPExec(batchClient, c.Addr, c.User, c.Pass)
 
-	batchTrips := make([]int, c.Iterations)
+	batchC := newCounters(c.Iterations)
 	batchTimes := stats.RunParallel(c.Iterations, c.Concurrency, func(idx int) time.Duration {
-		var before int
+		var bt, br, bw int
 		if *batchCC != nil {
-			before = (*batchCC).Trips()
+			bt, br, bw = (*batchCC).Trips(), (*batchCC).Reads(), (*batchCC).Writes()
 		}
 		start := time.Now()
 		url := fmt.Sprintf("https://%s/admin/config", c.Addr)
@@ -347,15 +386,15 @@ func HTTPS(c Config) []stats.Result {
 			return errDuration
 		}
 		if *batchCC != nil {
-			batchTrips[idx] = (*batchCC).Trips() - before
+			batchC.recordConnDelta(idx, *batchCC, bt, br, bw)
 		}
 		return time.Since(start)
 	})
 
 	results := []stats.Result{
-		stats.Summarize("https", "fresh-conn", c.Commands, c.Iterations, c.Concurrency, c.Profile, c.RTTms, freshTimes, freshTrips),
-		stats.Summarize("https", "keep-alive", c.Commands, c.Iterations, c.Concurrency, c.Profile, c.RTTms, reuseTimes, keepTrips),
-		stats.Summarize("https", "batch-post", c.Commands, c.Iterations, c.Concurrency, c.Profile, c.RTTms, batchTimes, batchTrips),
+		stats.Summarize("https", "fresh-conn", c.Commands, c.Iterations, c.Concurrency, c.Profile, c.RTTms, freshTimes, freshC.iter()),
+		stats.Summarize("https", "keep-alive", c.Commands, c.Iterations, c.Concurrency, c.Profile, c.RTTms, reuseTimes, keepC.iter()),
+		stats.Summarize("https", "batch-post", c.Commands, c.Iterations, c.Concurrency, c.Profile, c.RTTms, batchTimes, batchC.iter()),
 	}
 
 	// Mode 4: multi-command GET (ASA slash syntax)
@@ -370,11 +409,11 @@ func HTTPS(c Config) []stats.Result {
 		multiClient := &http.Client{Transport: multiTr, Timeout: 30 * time.Second}
 		_ = doHTTPExec(multiClient, c.Addr, c.User, c.Pass)
 
-		multiTrips := make([]int, c.Iterations)
+		multiC := newCounters(c.Iterations)
 		multiTimes := stats.RunParallel(c.Iterations, c.Concurrency, func(idx int) time.Duration {
-			var before int
+			var bt, br, bw int
 			if *multiCC != nil {
-				before = (*multiCC).Trips()
+				bt, br, bw = (*multiCC).Trips(), (*multiCC).Reads(), (*multiCC).Writes()
 			}
 			start := time.Now()
 			url := fmt.Sprintf("https://%s/admin/exec/%s", c.Addr, multiPath)
@@ -395,11 +434,11 @@ func HTTPS(c Config) []stats.Result {
 				return errDuration
 			}
 			if *multiCC != nil {
-				multiTrips[idx] = (*multiCC).Trips() - before
+				multiC.recordConnDelta(idx, *multiCC, bt, br, bw)
 			}
 			return time.Since(start)
 		})
-		results = append(results, stats.Summarize("https", "multi-cmd", c.Commands, c.Iterations, c.Concurrency, c.Profile, c.RTTms, multiTimes, multiTrips))
+		results = append(results, stats.Summarize("https", "multi-cmd", c.Commands, c.Iterations, c.Concurrency, c.Profile, c.RTTms, multiTimes, multiC.iter()))
 	}
 
 	return results
@@ -419,7 +458,7 @@ func Proxy(c ProxyConfig) []stats.Result {
 	tlsCfg := &tls.Config{InsecureSkipVerify: true}
 	payload := stats.GenerateExecPayload(c.Commands)
 
-	doProxy := func(addr string) (time.Duration, int) {
+	doProxy := func(addr string) (time.Duration, int, int, int) {
 		start := time.Now()
 		var cc *rtcount.Conn
 		tr := &http.Transport{
@@ -442,43 +481,43 @@ func Proxy(c ProxyConfig) []stats.Result {
 		url := fmt.Sprintf("https://%s/admin/config", addr)
 		req, err := http.NewRequest("POST", url, strings.NewReader(payload))
 		if err != nil {
-			return errDuration, 0
+			return errDuration, 0, 0, 0
 		}
 		req.SetBasicAuth(c.User, c.Pass)
 		resp, err := client.Do(req)
 		if err != nil {
 			log.Printf("proxy: %v", err)
-			return errDuration, 0
+			return errDuration, 0, 0, 0
 		}
 		_, _ = io.ReadAll(resp.Body)
 		resp.Body.Close()
 		if resp.StatusCode != http.StatusOK {
 			log.Printf("proxy: HTTP %d", resp.StatusCode)
-			return errDuration, 0
+			return errDuration, 0, 0, 0
 		}
-		var trips int
+		var trips, reads, writes int
 		if cc != nil {
-			trips = cc.Trips()
+			trips, reads, writes = cc.Trips(), cc.Reads(), cc.Writes()
 		}
-		return time.Since(start), trips
+		return time.Since(start), trips, reads, writes
 	}
 
-	freshTrips := make([]int, c.Iterations)
+	freshC := newCounters(c.Iterations)
 	freshTimes := stats.RunParallel(c.Iterations, c.Concurrency, func(idx int) time.Duration {
-		d, t := doProxy(c.FreshAddr)
-		freshTrips[idx] = t
+		d, t, r, w := doProxy(c.FreshAddr)
+		freshC.trips[idx], freshC.reads[idx], freshC.writes[idx] = t, r, w
 		return d
 	})
-	pooledTrips := make([]int, c.Iterations)
+	pooledC := newCounters(c.Iterations)
 	pooledTimes := stats.RunParallel(c.Iterations, c.Concurrency, func(idx int) time.Duration {
-		d, t := doProxy(c.PooledAddr)
-		pooledTrips[idx] = t
+		d, t, r, w := doProxy(c.PooledAddr)
+		pooledC.trips[idx], pooledC.reads[idx], pooledC.writes[idx] = t, r, w
 		return d
 	})
 
 	return []stats.Result{
-		stats.Summarize("proxy", "fresh-ssh", c.Commands, c.Iterations, c.Concurrency, c.Profile, c.RTTms, freshTimes, freshTrips),
-		stats.Summarize("proxy", "pooled-ssh", c.Commands, c.Iterations, c.Concurrency, c.Profile, c.RTTms, pooledTimes, pooledTrips),
+		stats.Summarize("proxy", "fresh-ssh", c.Commands, c.Iterations, c.Concurrency, c.Profile, c.RTTms, freshTimes, freshC.iter()),
+		stats.Summarize("proxy", "pooled-ssh", c.Commands, c.Iterations, c.Concurrency, c.Profile, c.RTTms, pooledTimes, pooledC.iter()),
 	}
 }
 

--- a/internal/bench/bench.go
+++ b/internal/bench/bench.go
@@ -156,7 +156,11 @@ func SSH(c Config) []stats.Result {
 		}
 		reuseC = newCounters(c.Iterations)
 		reuseTimes = stats.RunParallel(c.Iterations, c.Concurrency, func(idx int) time.Duration {
-			bt, br, bw := sharedCC.Trips(), sharedCC.Reads(), sharedCC.Writes()
+			// Delta counting on shared conn is only valid at concurrency=1.
+			var bt, br, bw int
+			if c.Concurrency == 1 {
+				bt, br, bw = sharedCC.Trips(), sharedCC.Reads(), sharedCC.Writes()
+			}
 			start := time.Now()
 			for i := 0; i < c.Commands; i++ {
 				sess, err := sharedConn.NewSession()
@@ -171,7 +175,9 @@ func SSH(c Config) []stats.Result {
 					return errDuration
 				}
 			}
-			reuseC.recordConnDelta(idx, sharedCC, bt, br, bw)
+			if c.Concurrency == 1 {
+				reuseC.recordConnDelta(idx, sharedCC, bt, br, bw)
+			}
 			return time.Since(start)
 		})
 		sharedConn.Close()
@@ -245,7 +251,10 @@ func SSH(c Config) []stats.Result {
 		}
 		ptyReuseC := newCounters(c.Iterations)
 		ptyReuseTimes := stats.RunParallel(c.Iterations, c.Concurrency, func(idx int) time.Duration {
-			bt, br, bw := ptyCC.Trips(), ptyCC.Reads(), ptyCC.Writes()
+			var bt, br, bw int
+			if c.Concurrency == 1 {
+				bt, br, bw = ptyCC.Trips(), ptyCC.Reads(), ptyCC.Writes()
+			}
 			start := time.Now()
 			sess, err := ptyConn.NewSession()
 			if err != nil {
@@ -256,7 +265,9 @@ func SSH(c Config) []stats.Result {
 				log.Printf("ssh pty-reuse: %v", err)
 				return errDuration
 			}
-			ptyReuseC.recordConnDelta(idx, ptyCC, bt, br, bw)
+			if c.Concurrency == 1 {
+				ptyReuseC.recordConnDelta(idx, ptyCC, bt, br, bw)
+			}
 			return time.Since(start)
 		})
 		ptyConn.Close()
@@ -339,7 +350,7 @@ func HTTPS(c Config) []stats.Result {
 	keepC := newCounters(c.Iterations)
 	reuseTimes := stats.RunParallel(c.Iterations, c.Concurrency, func(idx int) time.Duration {
 		var bt, br, bw int
-		if *keepCC != nil {
+		if c.Concurrency == 1 && *keepCC != nil {
 			bt, br, bw = (*keepCC).Trips(), (*keepCC).Reads(), (*keepCC).Writes()
 		}
 		start := time.Now()
@@ -349,7 +360,7 @@ func HTTPS(c Config) []stats.Result {
 				return errDuration
 			}
 		}
-		if *keepCC != nil {
+		if c.Concurrency == 1 && *keepCC != nil {
 			keepC.recordConnDelta(idx, *keepCC, bt, br, bw)
 		}
 		return time.Since(start)
@@ -364,7 +375,7 @@ func HTTPS(c Config) []stats.Result {
 	batchC := newCounters(c.Iterations)
 	batchTimes := stats.RunParallel(c.Iterations, c.Concurrency, func(idx int) time.Duration {
 		var bt, br, bw int
-		if *batchCC != nil {
+		if c.Concurrency == 1 && *batchCC != nil {
 			bt, br, bw = (*batchCC).Trips(), (*batchCC).Reads(), (*batchCC).Writes()
 		}
 		start := time.Now()
@@ -385,7 +396,7 @@ func HTTPS(c Config) []stats.Result {
 			log.Printf("https batch: HTTP %d", resp.StatusCode)
 			return errDuration
 		}
-		if *batchCC != nil {
+		if c.Concurrency == 1 && *batchCC != nil {
 			batchC.recordConnDelta(idx, *batchCC, bt, br, bw)
 		}
 		return time.Since(start)
@@ -412,7 +423,7 @@ func HTTPS(c Config) []stats.Result {
 		multiC := newCounters(c.Iterations)
 		multiTimes := stats.RunParallel(c.Iterations, c.Concurrency, func(idx int) time.Duration {
 			var bt, br, bw int
-			if *multiCC != nil {
+			if c.Concurrency == 1 && *multiCC != nil {
 				bt, br, bw = (*multiCC).Trips(), (*multiCC).Reads(), (*multiCC).Writes()
 			}
 			start := time.Now()
@@ -433,7 +444,7 @@ func HTTPS(c Config) []stats.Result {
 				log.Printf("https multi: HTTP %d", resp.StatusCode)
 				return errDuration
 			}
-			if *multiCC != nil {
+			if c.Concurrency == 1 && *multiCC != nil {
 				multiC.recordConnDelta(idx, *multiCC, bt, br, bw)
 			}
 			return time.Since(start)

--- a/internal/bench/http3.go
+++ b/internal/bench/http3.go
@@ -72,7 +72,7 @@ func HTTP3(c Config) []stats.Result {
 	keepC := newCounters(c.Iterations)
 	keepTimes := stats.RunParallel(c.Iterations, c.Concurrency, func(idx int) time.Duration {
 		var bt, br, bw int
-		if keepCC != nil {
+		if c.Concurrency == 1 && keepCC != nil {
 			bt, br, bw = keepCC.Trips(), keepCC.Reads(), keepCC.Writes()
 		}
 		start := time.Now()
@@ -82,7 +82,7 @@ func HTTP3(c Config) []stats.Result {
 				return errDuration
 			}
 		}
-		if keepCC != nil {
+		if c.Concurrency == 1 && keepCC != nil {
 			keepC.recordPacketDelta(idx, keepCC, bt, br, bw)
 		}
 		return time.Since(start)
@@ -99,7 +99,7 @@ func HTTP3(c Config) []stats.Result {
 	batchC := newCounters(c.Iterations)
 	batchTimes := stats.RunParallel(c.Iterations, c.Concurrency, func(idx int) time.Duration {
 		var bt, br, bw int
-		if batchCC != nil {
+		if c.Concurrency == 1 && batchCC != nil {
 			bt, br, bw = batchCC.Trips(), batchCC.Reads(), batchCC.Writes()
 		}
 		start := time.Now()
@@ -120,7 +120,7 @@ func HTTP3(c Config) []stats.Result {
 			log.Printf("http3 batch: HTTP %d", resp.StatusCode)
 			return errDuration
 		}
-		if batchCC != nil {
+		if c.Concurrency == 1 && batchCC != nil {
 			batchC.recordPacketDelta(idx, batchCC, bt, br, bw)
 		}
 		return time.Since(start)

--- a/internal/bench/http3.go
+++ b/internal/bench/http3.go
@@ -43,7 +43,7 @@ func HTTP3(c Config) []stats.Result {
 	tlsCfg := &tls.Config{InsecureSkipVerify: true, NextProtos: []string{http3.NextProtoH3}}
 
 	// Mode 1: fresh connection per iteration
-	freshTrips := make([]int, c.Iterations)
+	freshC := newCounters(c.Iterations)
 	freshTimes := stats.RunParallel(c.Iterations, c.Concurrency, func(idx int) time.Duration {
 		start := time.Now()
 		var cc *rtcount.PacketConn
@@ -57,7 +57,7 @@ func HTTP3(c Config) []stats.Result {
 			}
 		}
 		if cc != nil {
-			freshTrips[idx] = cc.Trips()
+			freshC.recordPacket(idx, cc)
 		}
 		tr.Close()
 		return time.Since(start)
@@ -67,13 +67,13 @@ func HTTP3(c Config) []stats.Result {
 	var keepCC *rtcount.PacketConn
 	keepTr := &http3.Transport{TLSClientConfig: tlsCfg.Clone(), Dial: h3Dial(&keepCC)}
 	keepClient := &http.Client{Transport: keepTr, Timeout: 30 * time.Second}
-	_ = doHTTPExec(keepClient, c.Addr, c.User, c.Pass) // warmup
+	_ = doHTTPExec(keepClient, c.Addr, c.User, c.Pass)
 
-	keepTrips := make([]int, c.Iterations)
+	keepC := newCounters(c.Iterations)
 	keepTimes := stats.RunParallel(c.Iterations, c.Concurrency, func(idx int) time.Duration {
-		var before int
+		var bt, br, bw int
 		if keepCC != nil {
-			before = keepCC.Trips()
+			bt, br, bw = keepCC.Trips(), keepCC.Reads(), keepCC.Writes()
 		}
 		start := time.Now()
 		for i := 0; i < c.Commands; i++ {
@@ -83,7 +83,7 @@ func HTTP3(c Config) []stats.Result {
 			}
 		}
 		if keepCC != nil {
-			keepTrips[idx] = keepCC.Trips() - before
+			keepC.recordPacketDelta(idx, keepCC, bt, br, bw)
 		}
 		return time.Since(start)
 	})
@@ -94,13 +94,13 @@ func HTTP3(c Config) []stats.Result {
 	var batchCC *rtcount.PacketConn
 	batchTr := &http3.Transport{TLSClientConfig: tlsCfg.Clone(), Dial: h3Dial(&batchCC)}
 	batchClient := &http.Client{Transport: batchTr, Timeout: 30 * time.Second}
-	_ = doHTTPExec(batchClient, c.Addr, c.User, c.Pass) // warmup
+	_ = doHTTPExec(batchClient, c.Addr, c.User, c.Pass)
 
-	batchTrips := make([]int, c.Iterations)
+	batchC := newCounters(c.Iterations)
 	batchTimes := stats.RunParallel(c.Iterations, c.Concurrency, func(idx int) time.Duration {
-		var before int
+		var bt, br, bw int
 		if batchCC != nil {
-			before = batchCC.Trips()
+			bt, br, bw = batchCC.Trips(), batchCC.Reads(), batchCC.Writes()
 		}
 		start := time.Now()
 		url := fmt.Sprintf("https://%s/admin/config", c.Addr)
@@ -121,16 +121,16 @@ func HTTP3(c Config) []stats.Result {
 			return errDuration
 		}
 		if batchCC != nil {
-			batchTrips[idx] = batchCC.Trips() - before
+			batchC.recordPacketDelta(idx, batchCC, bt, br, bw)
 		}
 		return time.Since(start)
 	})
 	batchTr.Close()
 
 	results := []stats.Result{
-		stats.Summarize("http3", "fresh-conn", c.Commands, c.Iterations, c.Concurrency, c.Profile, c.RTTms, freshTimes, freshTrips),
-		stats.Summarize("http3", "keep-alive", c.Commands, c.Iterations, c.Concurrency, c.Profile, c.RTTms, keepTimes, keepTrips),
-		stats.Summarize("http3", "batch-post", c.Commands, c.Iterations, c.Concurrency, c.Profile, c.RTTms, batchTimes, batchTrips),
+		stats.Summarize("http3", "fresh-conn", c.Commands, c.Iterations, c.Concurrency, c.Profile, c.RTTms, freshTimes, freshC.iter()),
+		stats.Summarize("http3", "keep-alive", c.Commands, c.Iterations, c.Concurrency, c.Profile, c.RTTms, keepTimes, keepC.iter()),
+		stats.Summarize("http3", "batch-post", c.Commands, c.Iterations, c.Concurrency, c.Profile, c.RTTms, batchTimes, batchC.iter()),
 	}
 
 	// Mode 4: 0-RTT resumption
@@ -141,7 +141,6 @@ func HTTP3(c Config) []stats.Result {
 		ClientSessionCache: sessionCache,
 	}
 
-	// Warmup: establish initial connection to get session ticket
 	warmTr := &http3.Transport{TLSClientConfig: zeroRTTCfg}
 	warmClient := &http.Client{Transport: warmTr, Timeout: 30 * time.Second}
 	if err := doHTTPExec(warmClient, c.Addr, c.User, c.Pass); err != nil {
@@ -150,7 +149,7 @@ func HTTP3(c Config) []stats.Result {
 	warmTr.Close()
 	time.Sleep(50 * time.Millisecond)
 
-	zeroTrips := make([]int, c.Iterations)
+	zeroC := newCounters(c.Iterations)
 	zeroTimes := stats.RunParallel(c.Iterations, c.Concurrency, func(idx int) time.Duration {
 		start := time.Now()
 		var cc *rtcount.PacketConn
@@ -168,12 +167,12 @@ func HTTP3(c Config) []stats.Result {
 			}
 		}
 		if cc != nil {
-			zeroTrips[idx] = cc.Trips()
+			zeroC.recordPacket(idx, cc)
 		}
 		tr.Close()
 		return time.Since(start)
 	})
-	results = append(results, stats.Summarize("http3", "0rtt-resumption", c.Commands, c.Iterations, c.Concurrency, c.Profile, c.RTTms, zeroTimes, zeroTrips))
+	results = append(results, stats.Summarize("http3", "0rtt-resumption", c.Commands, c.Iterations, c.Concurrency, c.Profile, c.RTTms, zeroTimes, zeroC.iter()))
 
 	return results
 }

--- a/internal/bench/tunnel.go
+++ b/internal/bench/tunnel.go
@@ -35,8 +35,7 @@ func Tunnel(c TunnelConfig) []stats.Result {
 func tunnelFresh(cfg *ssh.ClientConfig, c TunnelConfig, edgeAddr, transport, op string) []stats.Result {
 	batchPayload := stats.GenerateExecPayload(c.Commands)
 
-	// Mode 1: fresh SSH connection per iteration
-	freshTrips := make([]int, c.Iterations)
+	freshC := newCounters(c.Iterations)
 	freshTimes := stats.RunParallel(c.Iterations, c.Concurrency, func(idx int) time.Duration {
 		start := time.Now()
 		conn, cc, err := sshDialCounted(edgeAddr, cfg)
@@ -58,12 +57,11 @@ func tunnelFresh(cfg *ssh.ClientConfig, c TunnelConfig, edgeAddr, transport, op 
 				return errDuration
 			}
 		}
-		freshTrips[idx] = cc.Trips()
+		freshC.recordConn(idx, cc)
 		return time.Since(start)
 	})
 
-	// Mode 2: batch exec
-	batchTrips := make([]int, c.Iterations)
+	batchC := newCounters(c.Iterations)
 	batchTimes := stats.RunParallel(c.Iterations, c.Concurrency, func(idx int) time.Duration {
 		start := time.Now()
 		conn, cc, err := sshDialCounted(edgeAddr, cfg)
@@ -83,12 +81,12 @@ func tunnelFresh(cfg *ssh.ClientConfig, c TunnelConfig, edgeAddr, transport, op 
 			log.Printf("%s-batch exec: %v", op, err)
 			return errDuration
 		}
-		batchTrips[idx] = cc.Trips()
+		batchC.recordConn(idx, cc)
 		return time.Since(start)
 	})
 
 	return []stats.Result{
-		stats.Summarize(transport, op, c.Commands, c.Iterations, c.Concurrency, c.Profile, c.RTTms, freshTimes, freshTrips),
-		stats.Summarize(transport, op+"-batch", c.Commands, c.Iterations, c.Concurrency, c.Profile, c.RTTms, batchTimes, batchTrips),
+		stats.Summarize(transport, op, c.Commands, c.Iterations, c.Concurrency, c.Profile, c.RTTms, freshTimes, freshC.iter()),
+		stats.Summarize(transport, op+"-batch", c.Commands, c.Iterations, c.Concurrency, c.Profile, c.RTTms, batchTimes, batchC.iter()),
 	}
 }

--- a/internal/pktcount/extract_test.go
+++ b/internal/pktcount/extract_test.go
@@ -1,0 +1,72 @@
+package pktcount
+
+import "testing"
+
+func TestExtractPortsTCP(t *testing.T) {
+	// Minimal IPv4 TCP packet: 20-byte IP header + 4 bytes of TCP (src/dst port)
+	ip := make([]byte, 24)
+	ip[0] = 0x45       // version=4, IHL=5 (20 bytes)
+	ip[9] = 6          // protocol = TCP
+	ip[20] = 0x08      // src port = 2222
+	ip[21] = 0xAE
+	ip[22] = 0x20      // dst port = 8443
+	ip[23] = 0xFB
+
+	src, dst, ok := extractPorts(ip)
+	if !ok {
+		t.Fatal("extractPorts returned false")
+	}
+	if src != 2222 {
+		t.Errorf("src = %d, want 2222", src)
+	}
+	if dst != 8443 {
+		t.Errorf("dst = %d, want 8443", dst)
+	}
+}
+
+func TestExtractPortsUDP(t *testing.T) {
+	ip := make([]byte, 24)
+	ip[0] = 0x45
+	ip[9] = 17 // UDP
+	ip[20] = 0x20
+	ip[21] = 0xFC // src port = 8444
+	ip[22] = 0xC0
+	ip[23] = 0x01 // dst port = 49153
+
+	src, dst, ok := extractPorts(ip)
+	if !ok {
+		t.Fatal("extractPorts returned false")
+	}
+	if src != 8444 {
+		t.Errorf("src = %d, want 8444", src)
+	}
+	if dst != 49153 {
+		t.Errorf("dst = %d, want 49153", dst)
+	}
+}
+
+func TestExtractPortsRejectsNonIPv4(t *testing.T) {
+	ip := make([]byte, 24)
+	ip[0] = 0x60 // IPv6
+	_, _, ok := extractPorts(ip)
+	if ok {
+		t.Error("expected false for IPv6")
+	}
+}
+
+func TestExtractPortsRejectsICMP(t *testing.T) {
+	ip := make([]byte, 24)
+	ip[0] = 0x45
+	ip[9] = 1 // ICMP
+	_, _, ok := extractPorts(ip)
+	if ok {
+		t.Error("expected false for ICMP")
+	}
+}
+
+func TestExtractPortsTooShort(t *testing.T) {
+	_, _, ok := extractPorts(make([]byte, 10))
+	if ok {
+		t.Error("expected false for short packet")
+	}
+}

--- a/internal/pktcount/pktcount.go
+++ b/internal/pktcount/pktcount.go
@@ -7,7 +7,6 @@ import (
 	"sync"
 	"sync/atomic"
 	"syscall"
-	"unsafe"
 )
 
 // Counter captures packets on loopback filtered by port.
@@ -21,22 +20,33 @@ type Counter struct {
 }
 
 // New creates a packet counter for the given ports on loopback.
-// Call Start() to begin capturing, Snapshot() to read counts, Stop() to finish.
 func New(ports []int) (*Counter, error) {
-	fd, err := syscall.Socket(syscall.AF_PACKET, syscall.SOCK_RAW, int(htons(syscall.ETH_P_ALL)))
+	// SOCK_DGRAM gives a 4-byte cooked header (protocol family) instead of
+	// the 14-byte pseudo-Ethernet header from SOCK_RAW.
+	proto := int(htons(syscall.ETH_P_IP))
+	fd, err := syscall.Socket(syscall.AF_PACKET, syscall.SOCK_DGRAM, proto)
 	if err != nil {
 		return nil, err
 	}
 
 	// Bind to loopback (ifindex 1)
 	sa := &syscall.SockaddrLinklayer{
-		Protocol: htons(syscall.ETH_P_ALL),
+		Protocol: htons(syscall.ETH_P_IP),
 		Ifindex:  1, // lo
 	}
 	if err := syscall.Bind(fd, sa); err != nil {
 		syscall.Close(fd)
 		return nil, err
 	}
+
+	// Set read timeout once — 100ms lets us check the done channel periodically.
+	tv := syscall.Timeval{Sec: 0, Usec: 100_000}
+	_ = syscall.SetsockoptTimeval(fd, syscall.SOL_SOCKET, syscall.SO_RCVTIMEO, &tv)
+
+	// Only count outbound packets (PACKET_OUTGOING is not set for loopback
+	// in SOCK_DGRAM mode — loopback delivers each packet once to AF_PACKET).
+	// However, on some kernels loopback still delivers twice. We use
+	// PACKET_OUTGOING detection via SockaddrLinklayer.Pkttype to deduplicate.
 
 	pm := make(map[uint16]bool, len(ports))
 	for _, p := range ports {
@@ -66,6 +76,7 @@ func (c *Counter) Reset() {
 // Stop ends capture and closes the socket.
 func (c *Counter) Stop() {
 	close(c.done)
+	// Close fd to unblock Recvfrom, then wait for goroutine.
 	syscall.Close(c.fd)
 	c.wg.Wait()
 }
@@ -80,22 +91,24 @@ func (c *Counter) capture() {
 		default:
 		}
 
-		// Set a short read timeout so we can check done
-		tv := syscall.Timeval{Sec: 0, Usec: 100_000} // 100ms
-		_ = syscall.SetsockoptTimeval(c.fd, syscall.SOL_SOCKET, syscall.SO_RCVTIMEO, &tv)
-
-		n, _, err := syscall.Recvfrom(c.fd, buf, 0)
+		n, from, err := syscall.Recvfrom(c.fd, buf, 0)
 		if err != nil {
-			continue // timeout or signal
+			continue
 		}
-		if n < 4 {
+		if n < 20 { // minimum IP header
 			continue
 		}
 
-		// Loopback packets have a 4-byte Linux cooked header (protocol family).
-		// The IP header starts at offset 4.
-		pkt := buf[:n]
-		srcPort, dstPort, ok := extractPorts(pkt[4:])
+		// On loopback, AF_PACKET delivers each packet twice (TX + RX).
+		// Filter to only count incoming delivery (Pkttype == PACKET_HOST).
+		if sa, ok := from.(*syscall.SockaddrLinklayer); ok {
+			if sa.Pkttype == syscall.PACKET_OUTGOING {
+				continue // skip TX copy, count only RX delivery
+			}
+		}
+
+		// SOCK_DGRAM strips the link header; buf starts at IP header.
+		srcPort, dstPort, ok := extractPorts(buf[:n])
 		if !ok {
 			continue
 		}
@@ -114,24 +127,18 @@ func extractPorts(ip []byte) (src, dst uint16, ok bool) {
 	if len(ip) < 20 {
 		return 0, 0, false
 	}
-
 	version := ip[0] >> 4
 	if version != 4 {
 		return 0, 0, false
 	}
-
 	ihl := int(ip[0]&0x0f) * 4
 	proto := ip[9]
-
-	// Only TCP (6) and UDP (17)
-	if proto != 6 && proto != 17 {
+	if proto != 6 && proto != 17 { // TCP or UDP only
 		return 0, 0, false
 	}
-
 	if len(ip) < ihl+4 {
 		return 0, 0, false
 	}
-
 	transport := ip[ihl:]
 	src = binary.BigEndian.Uint16(transport[0:2])
 	dst = binary.BigEndian.Uint16(transport[2:4])
@@ -139,6 +146,5 @@ func extractPorts(ip []byte) (src, dst uint16, ok bool) {
 }
 
 func htons(v uint16) uint16 {
-	b := (*[2]byte)(unsafe.Pointer(&v))
-	return binary.BigEndian.Uint16(b[:])
+	return (v<<8)&0xff00 | v>>8
 }

--- a/internal/pktcount/pktcount.go
+++ b/internal/pktcount/pktcount.go
@@ -1,0 +1,144 @@
+// Package pktcount captures real packet counts on loopback using AF_PACKET.
+// Requires CAP_NET_RAW or root.
+package pktcount
+
+import (
+	"encoding/binary"
+	"sync"
+	"sync/atomic"
+	"syscall"
+	"unsafe"
+)
+
+// Counter captures packets on loopback filtered by port.
+type Counter struct {
+	fd    int
+	ports map[uint16]bool
+	in    atomic.Int64 // packets where dst port matches
+	out   atomic.Int64 // packets where src port matches
+	done  chan struct{}
+	wg    sync.WaitGroup
+}
+
+// New creates a packet counter for the given ports on loopback.
+// Call Start() to begin capturing, Snapshot() to read counts, Stop() to finish.
+func New(ports []int) (*Counter, error) {
+	fd, err := syscall.Socket(syscall.AF_PACKET, syscall.SOCK_RAW, int(htons(syscall.ETH_P_ALL)))
+	if err != nil {
+		return nil, err
+	}
+
+	// Bind to loopback (ifindex 1)
+	sa := &syscall.SockaddrLinklayer{
+		Protocol: htons(syscall.ETH_P_ALL),
+		Ifindex:  1, // lo
+	}
+	if err := syscall.Bind(fd, sa); err != nil {
+		syscall.Close(fd)
+		return nil, err
+	}
+
+	pm := make(map[uint16]bool, len(ports))
+	for _, p := range ports {
+		pm[uint16(p)] = true
+	}
+
+	return &Counter{fd: fd, ports: pm, done: make(chan struct{})}, nil
+}
+
+// Start begins capturing packets in a background goroutine.
+func (c *Counter) Start() {
+	c.wg.Add(1)
+	go c.capture()
+}
+
+// Snapshot returns current inbound and outbound packet counts.
+func (c *Counter) Snapshot() (in, out int) {
+	return int(c.in.Load()), int(c.out.Load())
+}
+
+// Reset zeroes the counters.
+func (c *Counter) Reset() {
+	c.in.Store(0)
+	c.out.Store(0)
+}
+
+// Stop ends capture and closes the socket.
+func (c *Counter) Stop() {
+	close(c.done)
+	syscall.Close(c.fd)
+	c.wg.Wait()
+}
+
+func (c *Counter) capture() {
+	defer c.wg.Done()
+	buf := make([]byte, 65536)
+	for {
+		select {
+		case <-c.done:
+			return
+		default:
+		}
+
+		// Set a short read timeout so we can check done
+		tv := syscall.Timeval{Sec: 0, Usec: 100_000} // 100ms
+		_ = syscall.SetsockoptTimeval(c.fd, syscall.SOL_SOCKET, syscall.SO_RCVTIMEO, &tv)
+
+		n, _, err := syscall.Recvfrom(c.fd, buf, 0)
+		if err != nil {
+			continue // timeout or signal
+		}
+		if n < 4 {
+			continue
+		}
+
+		// Loopback packets have a 4-byte Linux cooked header (protocol family).
+		// The IP header starts at offset 4.
+		pkt := buf[:n]
+		srcPort, dstPort, ok := extractPorts(pkt[4:])
+		if !ok {
+			continue
+		}
+
+		if c.ports[dstPort] {
+			c.in.Add(1)
+		}
+		if c.ports[srcPort] {
+			c.out.Add(1)
+		}
+	}
+}
+
+// extractPorts reads src/dst ports from an IP packet (TCP or UDP).
+func extractPorts(ip []byte) (src, dst uint16, ok bool) {
+	if len(ip) < 20 {
+		return 0, 0, false
+	}
+
+	version := ip[0] >> 4
+	if version != 4 {
+		return 0, 0, false
+	}
+
+	ihl := int(ip[0]&0x0f) * 4
+	proto := ip[9]
+
+	// Only TCP (6) and UDP (17)
+	if proto != 6 && proto != 17 {
+		return 0, 0, false
+	}
+
+	if len(ip) < ihl+4 {
+		return 0, 0, false
+	}
+
+	transport := ip[ihl:]
+	src = binary.BigEndian.Uint16(transport[0:2])
+	dst = binary.BigEndian.Uint16(transport[2:4])
+	return src, dst, true
+}
+
+func htons(v uint16) uint16 {
+	b := (*[2]byte)(unsafe.Pointer(&v))
+	return binary.BigEndian.Uint16(b[:])
+}

--- a/internal/pktcount/pktcount_test.go
+++ b/internal/pktcount/pktcount_test.go
@@ -1,0 +1,61 @@
+//go:build pktcount_root
+
+package pktcount
+
+import (
+	"net"
+	"testing"
+	"time"
+)
+
+func TestCounterTCP(t *testing.T) {
+	// Start a TCP listener on a known port
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer ln.Close()
+	port := ln.Addr().(*net.TCPAddr).Port
+
+	pc, err := New([]int{port})
+	if err != nil {
+		t.Fatalf("New: %v (requires CAP_NET_RAW)", err)
+	}
+	pc.Start()
+	defer pc.Stop()
+
+	// Accept in background
+	go func() {
+		c, _ := ln.Accept()
+		if c != nil {
+			buf := make([]byte, 64)
+			_, _ = c.Read(buf)
+			_, _ = c.Write([]byte("pong"))
+			c.Close()
+		}
+	}()
+
+	time.Sleep(50 * time.Millisecond)
+	pc.Reset()
+
+	// Connect and exchange data
+	c, err := net.Dial("tcp", ln.Addr().String())
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, _ = c.Write([]byte("ping"))
+	buf := make([]byte, 64)
+	_, _ = c.Read(buf)
+	c.Close()
+
+	time.Sleep(200 * time.Millisecond) // let packets be captured
+
+	in, out := pc.Snapshot()
+	t.Logf("packets: in=%d out=%d", in, out)
+	if in == 0 {
+		t.Error("expected in > 0")
+	}
+	if out == 0 {
+		t.Error("expected out > 0")
+	}
+}

--- a/internal/rtcount/rtcount.go
+++ b/internal/rtcount/rtcount.go
@@ -1,7 +1,6 @@
-// Package rtcount provides a net.Conn wrapper that counts application-level
-// round trips by tracking I/O direction changes. A direction change from
-// write to read (or read to write) indicates a round trip — the client
-// sent data and is now waiting for a response.
+// Package rtcount provides net.Conn and net.PacketConn wrappers that count
+// application-level round trips (write→read direction changes) and individual
+// read/write calls (packet-level I/O operations).
 package rtcount
 
 import (
@@ -9,19 +8,22 @@ import (
 	"sync/atomic"
 )
 
-// Conn wraps a net.Conn and counts direction changes.
+// Conn wraps a net.Conn and counts direction changes and I/O calls.
 type Conn struct {
 	net.Conn
 	trips   atomic.Int64
+	reads   atomic.Int64
+	writes  atomic.Int64
 	lastDir atomic.Int32 // 0=none, 1=read, 2=write
 }
 
-// Wrap returns a Conn that counts round trips on c.
+// Wrap returns a Conn that counts round trips and packets on c.
 func Wrap(c net.Conn) *Conn {
 	return &Conn{Conn: c}
 }
 
 func (c *Conn) Read(b []byte) (int, error) {
+	c.reads.Add(1)
 	if c.lastDir.Swap(1) == 2 {
 		c.trips.Add(1)
 	}
@@ -29,28 +31,36 @@ func (c *Conn) Read(b []byte) (int, error) {
 }
 
 func (c *Conn) Write(b []byte) (int, error) {
+	c.writes.Add(1)
 	c.lastDir.Store(2)
 	return c.Conn.Write(b)
 }
 
 // Trips returns the number of observed round trips.
-func (c *Conn) Trips() int {
-	return int(c.trips.Load())
-}
+func (c *Conn) Trips() int { return int(c.trips.Load()) }
 
-// PacketConn wraps a net.PacketConn and counts direction changes.
+// Reads returns the number of Read calls (inbound packets).
+func (c *Conn) Reads() int { return int(c.reads.Load()) }
+
+// Writes returns the number of Write calls (outbound packets).
+func (c *Conn) Writes() int { return int(c.writes.Load()) }
+
+// PacketConn wraps a net.PacketConn and counts direction changes and I/O calls.
 type PacketConn struct {
 	net.PacketConn
 	trips   atomic.Int64
+	reads   atomic.Int64
+	writes  atomic.Int64
 	lastDir atomic.Int32
 }
 
-// WrapPacket returns a PacketConn that counts round trips on pc.
+// WrapPacket returns a PacketConn that counts round trips and packets on pc.
 func WrapPacket(pc net.PacketConn) *PacketConn {
 	return &PacketConn{PacketConn: pc}
 }
 
 func (c *PacketConn) ReadFrom(b []byte) (int, net.Addr, error) {
+	c.reads.Add(1)
 	if c.lastDir.Swap(1) == 2 {
 		c.trips.Add(1)
 	}
@@ -58,11 +68,16 @@ func (c *PacketConn) ReadFrom(b []byte) (int, net.Addr, error) {
 }
 
 func (c *PacketConn) WriteTo(b []byte, addr net.Addr) (int, error) {
+	c.writes.Add(1)
 	c.lastDir.Store(2)
 	return c.PacketConn.WriteTo(b, addr)
 }
 
 // Trips returns the number of observed round trips.
-func (c *PacketConn) Trips() int {
-	return int(c.trips.Load())
-}
+func (c *PacketConn) Trips() int { return int(c.trips.Load()) }
+
+// Reads returns the number of ReadFrom calls (inbound packets).
+func (c *PacketConn) Reads() int { return int(c.reads.Load()) }
+
+// Writes returns the number of WriteTo calls (outbound packets).
+func (c *PacketConn) Writes() int { return int(c.writes.Load()) }

--- a/internal/rtcount/rtcount_test.go
+++ b/internal/rtcount/rtcount_test.go
@@ -12,7 +12,6 @@ func TestConnTrips(t *testing.T) {
 
 	cc := Wrap(c)
 
-	// Write then read = 1 trip
 	go func() {
 		buf := make([]byte, 5)
 		_, _ = s.Read(buf)
@@ -26,8 +25,14 @@ func TestConnTrips(t *testing.T) {
 	if got := cc.Trips(); got != 1 {
 		t.Errorf("Trips() = %d, want 1", got)
 	}
+	if got := cc.Reads(); got != 1 {
+		t.Errorf("Reads() = %d, want 1", got)
+	}
+	if got := cc.Writes(); got != 1 {
+		t.Errorf("Writes() = %d, want 1", got)
+	}
 
-	// Another write→read = 2 total
+	// Another write→read = 2 total trips, 2 reads, 2 writes
 	go func() {
 		buf := make([]byte, 4)
 		_, _ = s.Read(buf)
@@ -39,6 +44,12 @@ func TestConnTrips(t *testing.T) {
 
 	if got := cc.Trips(); got != 2 {
 		t.Errorf("Trips() = %d, want 2", got)
+	}
+	if got := cc.Reads(); got != 2 {
+		t.Errorf("Reads() = %d, want 2", got)
+	}
+	if got := cc.Writes(); got != 2 {
+		t.Errorf("Writes() = %d, want 2", got)
 	}
 }
 
@@ -56,14 +67,19 @@ func TestConnConsecutiveWritesCountOnce(t *testing.T) {
 		_, _ = s.Write([]byte("ok"))
 	}()
 
-	// Two consecutive writes should not increment trips
 	_, _ = cc.Write([]byte("a"))
 	_, _ = cc.Write([]byte("b"))
 	buf := make([]byte, 2)
 	_, _ = cc.Read(buf)
 
 	if got := cc.Trips(); got != 1 {
-		t.Errorf("Trips() = %d, want 1 (consecutive writes should count as one direction)", got)
+		t.Errorf("Trips() = %d, want 1", got)
+	}
+	if got := cc.Writes(); got != 2 {
+		t.Errorf("Writes() = %d, want 2 (each Write call counted)", got)
+	}
+	if got := cc.Reads(); got != 1 {
+		t.Errorf("Reads() = %d, want 1", got)
 	}
 }
 
@@ -81,7 +97,6 @@ func TestPacketConnTrips(t *testing.T) {
 
 	cc := WrapPacket(a)
 
-	// Write to b, then read response
 	go func() {
 		buf := make([]byte, 64)
 		n, addr, _ := b.ReadFrom(buf)
@@ -94,5 +109,11 @@ func TestPacketConnTrips(t *testing.T) {
 
 	if got := cc.Trips(); got != 1 {
 		t.Errorf("Trips() = %d, want 1", got)
+	}
+	if got := cc.Reads(); got != 1 {
+		t.Errorf("Reads() = %d, want 1", got)
+	}
+	if got := cc.Writes(); got != 1 {
+		t.Errorf("Writes() = %d, want 1", got)
 	}
 }

--- a/internal/stats/stats.go
+++ b/internal/stats/stats.go
@@ -25,8 +25,10 @@ type Result struct {
 	Latency     string  `json:"latency_profile"`
 	RTTms       float64 `json:"simulated_rtt_ms"`
 	RoundTrips  int     `json:"round_trips,omitempty"`
-	Reads       int     `json:"reads,omitempty"`
-	Writes      int     `json:"writes,omitempty"`
+	ReadOps     int     `json:"read_ops,omitempty"`
+	WriteOps    int     `json:"write_ops,omitempty"`
+	PacketsIn   int     `json:"packets_in,omitempty"`
+	PacketsOut  int     `json:"packets_out,omitempty"`
 	AvgMs       float64 `json:"avg_ms"`
 	MinMs       float64 `json:"min_ms"`
 	MaxMs       float64 `json:"max_ms"`
@@ -100,8 +102,8 @@ func Summarize(transport, op string, cmds, iterations, concurrency int, profile 
 		Latency:     profile,
 		RTTms:       rttMs,
 		RoundTrips:  medianInts(ic.Trips),
-		Reads:       medianInts(ic.Reads),
-		Writes:      medianInts(ic.Writes),
+		ReadOps:     medianInts(ic.Reads),
+		WriteOps:    medianInts(ic.Writes),
 		AvgMs:       avg,
 		MinMs:       valid[0],
 		MaxMs:       valid[n-1],

--- a/internal/stats/stats.go
+++ b/internal/stats/stats.go
@@ -2,7 +2,6 @@
 package stats
 
 import (
-	"fmt"
 	"log"
 	"math"
 	"sort"
@@ -163,7 +162,7 @@ func RunParallel(iterations, concurrency int, fn func(idx int) time.Duration) []
 func GenerateExecPayload(n int) string {
 	var b strings.Builder
 	for i := 0; i < n; i++ {
-		fmt.Fprintf(&b, "show version\n")
+		b.WriteString("show version\n")
 	}
 	return b.String()
 }

--- a/internal/stats/stats.go
+++ b/internal/stats/stats.go
@@ -25,6 +25,8 @@ type Result struct {
 	Latency     string  `json:"latency_profile"`
 	RTTms       float64 `json:"simulated_rtt_ms"`
 	RoundTrips  int     `json:"round_trips,omitempty"`
+	Reads       int     `json:"reads,omitempty"`
+	Writes      int     `json:"writes,omitempty"`
 	AvgMs       float64 `json:"avg_ms"`
 	MinMs       float64 `json:"min_ms"`
 	MaxMs       float64 `json:"max_ms"`
@@ -33,10 +35,17 @@ type Result struct {
 	StddevMs    float64 `json:"stddev_ms"`
 }
 
+// IterCounts holds per-iteration counters collected alongside durations.
+type IterCounts struct {
+	Trips  []int
+	Reads  []int
+	Writes []int
+}
+
 // Summarize computes statistics from a slice of durations.
-// An optional trips slice provides per-iteration round-trip counts;
-// the median value is stored in the result.
-func Summarize(transport, op string, cmds, iterations, concurrency int, profile string, rttMs float64, times []time.Duration, trips ...[]int) Result {
+// An optional IterCounts provides per-iteration round-trip and packet counts;
+// median values are stored in the result.
+func Summarize(transport, op string, cmds, iterations, concurrency int, profile string, rttMs float64, times []time.Duration, counts ...IterCounts) Result {
 	valid := make([]float64, 0, len(times))
 	errors := 0
 	for _, t := range times {
@@ -76,6 +85,11 @@ func Summarize(transport, op string, cmds, iterations, concurrency int, profile 
 		stddev = math.Sqrt(variance / float64(n-1))
 	}
 
+	var ic IterCounts
+	if len(counts) > 0 {
+		ic = counts[0]
+	}
+
 	return Result{
 		Transport:   transport,
 		Operation:   op,
@@ -85,7 +99,9 @@ func Summarize(transport, op string, cmds, iterations, concurrency int, profile 
 		Concurrency: concurrency,
 		Latency:     profile,
 		RTTms:       rttMs,
-		RoundTrips:  medianTrips(trips),
+		RoundTrips:  medianInts(ic.Trips),
+		Reads:       medianInts(ic.Reads),
+		Writes:      medianInts(ic.Writes),
 		AvgMs:       avg,
 		MinMs:       valid[0],
 		MaxMs:       valid[n-1],
@@ -95,15 +111,15 @@ func Summarize(transport, op string, cmds, iterations, concurrency int, profile 
 	}
 }
 
-// medianTrips returns the median of the first trips slice, or 0 if empty.
-func medianTrips(trips [][]int) int {
-	if len(trips) == 0 || len(trips[0]) == 0 {
+// medianInts returns the median of a slice, or 0 if empty.
+func medianInts(s []int) int {
+	if len(s) == 0 {
 		return 0
 	}
-	s := make([]int, len(trips[0]))
-	copy(s, trips[0])
-	sort.Ints(s)
-	return s[len(s)/2]
+	c := make([]int, len(s))
+	copy(c, s)
+	sort.Ints(c)
+	return c[len(c)/2]
 }
 
 // Percentile returns the p-th percentile from a sorted slice.

--- a/internal/stats/stats_test.go
+++ b/internal/stats/stats_test.go
@@ -175,11 +175,11 @@ func TestSummarizeWithTrips(t *testing.T) {
 	if r.RoundTrips != 5 { // median of [5, 5, 7] = 5
 		t.Errorf("RoundTrips = %d, want 5", r.RoundTrips)
 	}
-	if r.Reads != 10 { // median of [10, 10, 12] = 10
-		t.Errorf("Reads = %d, want 10", r.Reads)
+	if r.ReadOps != 10 { // median of [10, 10, 12] = 10
+		t.Errorf("ReadOps = %d, want 10", r.ReadOps)
 	}
-	if r.Writes != 8 { // median of [8, 8, 9] = 8
-		t.Errorf("Writes = %d, want 8", r.Writes)
+	if r.WriteOps != 8 { // median of [8, 8, 9] = 8
+		t.Errorf("WriteOps = %d, want 8", r.WriteOps)
 	}
 }
 
@@ -189,7 +189,7 @@ func TestSummarizeWithoutTrips(t *testing.T) {
 	if r.RoundTrips != 0 {
 		t.Errorf("RoundTrips = %d, want 0 when no counts provided", r.RoundTrips)
 	}
-	if r.Reads != 0 {
-		t.Errorf("Reads = %d, want 0 when no counts provided", r.Reads)
+	if r.ReadOps != 0 {
+		t.Errorf("ReadOps = %d, want 0 when no counts provided", r.ReadOps)
 	}
 }

--- a/internal/stats/stats_test.go
+++ b/internal/stats/stats_test.go
@@ -166,10 +166,20 @@ func TestRunParallelCountsErrors(t *testing.T) {
 
 func TestSummarizeWithTrips(t *testing.T) {
 	times := []time.Duration{10 * time.Millisecond, 20 * time.Millisecond, 15 * time.Millisecond}
-	trips := []int{5, 7, 5}
-	r := Summarize("ssh", "fresh-conn", 1, 3, 1, "local", 0, times, trips)
+	ic := IterCounts{
+		Trips:  []int{5, 7, 5},
+		Reads:  []int{10, 12, 10},
+		Writes: []int{8, 9, 8},
+	}
+	r := Summarize("ssh", "fresh-conn", 1, 3, 1, "local", 0, times, ic)
 	if r.RoundTrips != 5 { // median of [5, 5, 7] = 5
 		t.Errorf("RoundTrips = %d, want 5", r.RoundTrips)
+	}
+	if r.Reads != 10 { // median of [10, 10, 12] = 10
+		t.Errorf("Reads = %d, want 10", r.Reads)
+	}
+	if r.Writes != 8 { // median of [8, 8, 9] = 8
+		t.Errorf("Writes = %d, want 8", r.Writes)
 	}
 }
 
@@ -177,6 +187,9 @@ func TestSummarizeWithoutTrips(t *testing.T) {
 	times := []time.Duration{10 * time.Millisecond}
 	r := Summarize("https", "keep-alive", 1, 1, 1, "local", 0, times)
 	if r.RoundTrips != 0 {
-		t.Errorf("RoundTrips = %d, want 0 when no trips provided", r.RoundTrips)
+		t.Errorf("RoundTrips = %d, want 0 when no counts provided", r.RoundTrips)
+	}
+	if r.Reads != 0 {
+		t.Errorf("Reads = %d, want 0 when no counts provided", r.Reads)
 	}
 }


### PR DESCRIPTION
Closes #13

## What

Captures the actual number of Read/Write calls (packet-level I/O) on every benchmark connection, alongside the round-trip counts from #12.

## How

Extended the existing `rtcount` wrappers with `reads`/`writes` atomic counters. Every `Read()` or `Write()` call increments the counter — these map to individual TCP segments or UDP datagrams.

Introduced `stats.IterCounts` struct to cleanly pass trips/reads/writes through `Summarize()`, replacing the raw `[]int` variadic from #12. Added a `counters` helper in the bench package to collect all three from rtcount wrappers.

## Sample output (2 commands, local)

```
TRANSPORT  OPERATION        CMDS  RT  READS  WRITES
ssh        fresh-conn       2     11  25     13
ssh        reuse-conn       2     4   4      6
ssh        pty-fresh        2     13  69     15
https      fresh-conn       2     4   6      8
https      keep-alive       2     2   2      2
https      batch-post       2     1   1      1
http3      fresh-conn       2     4   9      9
http3      keep-alive       2     2   4      4
```

SSH fresh-conn: 38 total I/O ops. HTTPS fresh-conn: 14. HTTPS keep-alive: 4.

## Changes

- `internal/rtcount/` — added `reads`/`writes` counters and `Reads()`/`Writes()` accessors
- `internal/stats/` — `IterCounts` struct, `Result.Reads`/`Result.Writes` fields
- `internal/bench/` — `counters` helper, all bench functions updated
- `cmd/clibench/format.go` — READS/WRITES columns in table and CSV