### PR TITLE
fix: review followups — test assertions, API cleanup, signal handler

### DIFF
--- a/cmd/clibench/bench.go
+++ b/cmd/clibench/bench.go
@@ -98,8 +98,9 @@ func (b *BenchCmd) Run() error {
 		go func() {
 			<-sigCh
 			netem.Teardown()
-			os.Exit(1)
+			os.Exit(0)
 		}()
+		defer signal.Stop(sigCh)
 
 		log.Printf("tc netem: %dms one-way on ports %v, %dms on ports %v",
 			delay.Milliseconds(), wanPorts, campusDelay.Milliseconds(), campusPorts)

--- a/internal/bench/bench.go
+++ b/internal/bench/bench.go
@@ -283,21 +283,24 @@ func HTTPS(c Config) []stats.Result {
 
 	tlsCfg := &tls.Config{InsecureSkipVerify: true}
 
+	// countedTr wraps an http.Transport with the rtcount.Conn it created.
+	type countedTr struct {
+		*http.Transport
+		cc *rtcount.Conn
+	}
+
 	// countingTransport returns an http.Transport that wraps connections with rtcount.
-	// The returned *rtcount.Conn pointer is set on first dial.
-	countingTransport := func(disableKeepAlive bool) (*http.Transport, **rtcount.Conn) {
-		cc := new(*rtcount.Conn)
-		tr := &http.Transport{
-			TLSClientConfig:   tlsCfg,
-			DisableKeepAlives: disableKeepAlive,
+	countingTransport := func() *countedTr {
+		ct := &countedTr{}
+		ct.Transport = &http.Transport{
+			TLSClientConfig: tlsCfg,
 			DialTLSContext: func(ctx context.Context, network, addr string) (net.Conn, error) {
 				tc, err := net.Dial(network, addr)
 				if err != nil {
 					return nil, err
 				}
-				wrapped := rtcount.Wrap(tc)
-				*cc = wrapped
-				tlsConn := tls.Client(wrapped, tlsCfg)
+				ct.cc = rtcount.Wrap(tc)
+				tlsConn := tls.Client(ct.cc, tlsCfg)
 				if err := tlsConn.HandshakeContext(ctx); err != nil {
 					tc.Close()
 					return nil, err
@@ -305,7 +308,7 @@ func HTTPS(c Config) []stats.Result {
 				return tlsConn, nil
 			},
 		}
-		return tr, cc
+		return ct
 	}
 
 	// Mode 1: fresh connection per iteration
@@ -343,15 +346,15 @@ func HTTPS(c Config) []stats.Result {
 	})
 
 	// Mode 2: keep-alive — shared connection, count per iteration
-	keepTr, keepCC := countingTransport(false)
-	keepClient := &http.Client{Transport: keepTr, Timeout: 30 * time.Second}
+	keepTr := countingTransport()
+	keepClient := &http.Client{Transport: keepTr.Transport, Timeout: 30 * time.Second}
 	_ = doHTTPExec(keepClient, c.Addr, c.User, c.Pass)
 
 	keepC := newCounters(c.Iterations)
 	reuseTimes := stats.RunParallel(c.Iterations, c.Concurrency, func(idx int) time.Duration {
 		var bt, br, bw int
-		if c.Concurrency == 1 && *keepCC != nil {
-			bt, br, bw = (*keepCC).Trips(), (*keepCC).Reads(), (*keepCC).Writes()
+		if c.Concurrency == 1 && keepTr.cc != nil {
+			bt, br, bw = keepTr.cc.Trips(), keepTr.cc.Reads(), keepTr.cc.Writes()
 		}
 		start := time.Now()
 		for i := 0; i < c.Commands; i++ {
@@ -360,23 +363,23 @@ func HTTPS(c Config) []stats.Result {
 				return errDuration
 			}
 		}
-		if c.Concurrency == 1 && *keepCC != nil {
-			keepC.recordConnDelta(idx, *keepCC, bt, br, bw)
+		if c.Concurrency == 1 && keepTr.cc != nil {
+			keepC.recordConnDelta(idx, keepTr.cc, bt, br, bw)
 		}
 		return time.Since(start)
 	})
 
 	// Mode 3: batch POST
 	batchPayload := stats.GenerateExecPayload(c.Commands)
-	batchTr, batchCC := countingTransport(false)
-	batchClient := &http.Client{Transport: batchTr, Timeout: 30 * time.Second}
+	batchTr := countingTransport()
+	batchClient := &http.Client{Transport: batchTr.Transport, Timeout: 30 * time.Second}
 	_ = doHTTPExec(batchClient, c.Addr, c.User, c.Pass)
 
 	batchC := newCounters(c.Iterations)
 	batchTimes := stats.RunParallel(c.Iterations, c.Concurrency, func(idx int) time.Duration {
 		var bt, br, bw int
-		if c.Concurrency == 1 && *batchCC != nil {
-			bt, br, bw = (*batchCC).Trips(), (*batchCC).Reads(), (*batchCC).Writes()
+		if c.Concurrency == 1 && batchTr.cc != nil {
+			bt, br, bw = batchTr.cc.Trips(), batchTr.cc.Reads(), batchTr.cc.Writes()
 		}
 		start := time.Now()
 		url := fmt.Sprintf("https://%s/admin/config", c.Addr)
@@ -396,8 +399,8 @@ func HTTPS(c Config) []stats.Result {
 			log.Printf("https batch: HTTP %d", resp.StatusCode)
 			return errDuration
 		}
-		if c.Concurrency == 1 && *batchCC != nil {
-			batchC.recordConnDelta(idx, *batchCC, bt, br, bw)
+		if c.Concurrency == 1 && batchTr.cc != nil {
+			batchC.recordConnDelta(idx, batchTr.cc, bt, br, bw)
 		}
 		return time.Since(start)
 	})
@@ -416,15 +419,15 @@ func HTTPS(c Config) []stats.Result {
 		}
 		multiPath := strings.Join(cmdParts, "/")
 
-		multiTr, multiCC := countingTransport(false)
-		multiClient := &http.Client{Transport: multiTr, Timeout: 30 * time.Second}
+		multiTr := countingTransport()
+		multiClient := &http.Client{Transport: multiTr.Transport, Timeout: 30 * time.Second}
 		_ = doHTTPExec(multiClient, c.Addr, c.User, c.Pass)
 
 		multiC := newCounters(c.Iterations)
 		multiTimes := stats.RunParallel(c.Iterations, c.Concurrency, func(idx int) time.Duration {
 			var bt, br, bw int
-			if c.Concurrency == 1 && *multiCC != nil {
-				bt, br, bw = (*multiCC).Trips(), (*multiCC).Reads(), (*multiCC).Writes()
+			if c.Concurrency == 1 && multiTr.cc != nil {
+				bt, br, bw = multiTr.cc.Trips(), multiTr.cc.Reads(), multiTr.cc.Writes()
 			}
 			start := time.Now()
 			url := fmt.Sprintf("https://%s/admin/exec/%s", c.Addr, multiPath)
@@ -444,8 +447,8 @@ func HTTPS(c Config) []stats.Result {
 				log.Printf("https multi: HTTP %d", resp.StatusCode)
 				return errDuration
 			}
-			if c.Concurrency == 1 && *multiCC != nil {
-				multiC.recordConnDelta(idx, *multiCC, bt, br, bw)
+			if c.Concurrency == 1 && multiTr.cc != nil {
+				multiC.recordConnDelta(idx, multiTr.cc, bt, br, bw)
 			}
 			return time.Since(start)
 		})

--- a/internal/bench/bench_test.go
+++ b/internal/bench/bench_test.go
@@ -79,6 +79,15 @@ func assertResults(t *testing.T, results []stats.Result, transport string, minMo
 		if r.AvgMs <= 0 {
 			t.Errorf("%s/%s: avg_ms should be > 0, got %f", r.Transport, r.Operation, r.AvgMs)
 		}
+		if r.RoundTrips <= 0 {
+			t.Errorf("%s/%s: round_trips should be > 0, got %d", r.Transport, r.Operation, r.RoundTrips)
+		}
+		if r.ReadOps <= 0 {
+			t.Errorf("%s/%s: read_ops should be > 0, got %d", r.Transport, r.Operation, r.ReadOps)
+		}
+		if r.WriteOps <= 0 {
+			t.Errorf("%s/%s: write_ops should be > 0, got %d", r.Transport, r.Operation, r.WriteOps)
+		}
 	}
 }
 


### PR DESCRIPTION
Lower-priority fixes from the code review.

## Changes

1. **Bench tests assert counter values** — `assertResults` now checks `RoundTrips > 0`, `ReadOps > 0`, `WriteOps > 0` for every mode. If counter plumbing breaks, tests fail immediately.

2. **Replace `countingTransport` double-pointer** — the `(**rtcount.Conn)` return was confusing. Replaced with a `countedTr` struct that holds both the `*http.Transport` and the `*rtcount.Conn` with clear field access (`keepTr.cc` instead of `*keepCC`).

3. **Signal handler cleanup** — added `signal.Stop(sigCh)` on normal exit so the handler goroutine doesn't leak. Changed `os.Exit(1)` to `os.Exit(0)` since SIGINT is a normal shutdown.

## Testing

All existing tests pass, including the new counter assertions across SSH (5 modes), HTTPS (4 modes), HTTP/3 (4 modes), Proxy (2 modes), and Tunnel (4 modes).