### PR TITLE
fix: P0 architecture issues — build tags, error handling, cleanup

### DIFF
--- a/cmd/clibench/bench.go
+++ b/cmd/clibench/bench.go
@@ -93,15 +93,6 @@ func (b *BenchCmd) Run() error {
 		}
 		defer netem.Teardown()
 
-		sigCh := make(chan os.Signal, 1)
-		signal.Notify(sigCh, syscall.SIGINT, syscall.SIGTERM)
-		go func() {
-			<-sigCh
-			netem.Teardown()
-			os.Exit(0)
-		}()
-		defer signal.Stop(sigCh)
-
 		log.Printf("tc netem: %dms one-way on ports %v, %dms on ports %v",
 			delay.Milliseconds(), wanPorts, campusDelay.Milliseconds(), campusPorts)
 	} else if b.Userspace && delay > 0 {
@@ -115,70 +106,92 @@ func (b *BenchCmd) Run() error {
 		return ln
 	}
 
-	startSSH := func(addr string, d time.Duration) {
+	startSSH := func(addr string, d time.Duration) error {
 		ln, err := net.Listen("tcp", addr)
 		if err != nil {
-			log.Fatalf("listen %s: %v", addr, err)
+			return fmt.Errorf("listen %s: %w", addr, err)
 		}
 		srv, err := sshserver.New(addr, dev)
 		if err != nil {
-			log.Fatalf("ssh %s: %v", addr, err)
+			ln.Close()
+			return fmt.Errorf("ssh %s: %w", addr, err)
 		}
 		srv.SetListener(wrapListener(ln, d))
 		go srv.ListenAndServe()
+		return nil
 	}
 
-	startHTTPS := func(addr string, d time.Duration) {
+	startHTTPS := func(addr string, d time.Duration) error {
 		ln, err := net.Listen("tcp", addr)
 		if err != nil {
-			log.Fatalf("listen %s: %v", addr, err)
+			return fmt.Errorf("listen %s: %w", addr, err)
 		}
 		srv := httpserver.New(addr, dev)
 		srv.SetListener(wrapListener(ln, d))
 		go srv.ListenAndServeTLS()
+		return nil
 	}
 
-	startProxy := func(addr, backend string, pooled bool, d time.Duration) {
+	startProxy := func(addr, backend string, pooled bool, d time.Duration) error {
 		ln, err := net.Listen("tcp", addr)
 		if err != nil {
-			log.Fatalf("listen %s: %v", addr, err)
+			return fmt.Errorf("listen %s: %w", addr, err)
 		}
 		p := proxy.New(addr, backend, b.User, b.Pass, pooled)
 		p.SetListener(wrapListener(ln, d))
 		go p.ListenAndServeTLS()
+		return nil
 	}
 
-	startSSH(sshAddr, delay)
-	startHTTPS(httpsAddr, delay)
-	startSSH(backendSSHAddr, campusDelay)
-	startProxy(proxyAddr, backendSSHAddr, false, delay)
-	startProxy(proxyPooledAddr, backendSSHAddr, true, delay)
+	if err := startSSH(sshAddr, delay); err != nil {
+		return err
+	}
+	if err := startHTTPS(httpsAddr, delay); err != nil {
+		return err
+	}
+	if err := startSSH(backendSSHAddr, campusDelay); err != nil {
+		return err
+	}
+	if err := startProxy(proxyAddr, backendSSHAddr, false, delay); err != nil {
+		return err
+	}
+	if err := startProxy(proxyPooledAddr, backendSSHAddr, true, delay); err != nil {
+		return err
+	}
 
 	h3srv := http3server.New(http3Addr, dev)
 	go h3srv.ListenAndServe()
 
 	// Tunnel: site proxy (HTTPS frontend, WAN delay) → backend SSH (campus delay)
-	startProxy(tunnelSiteHTTPSAddr, backendSSHAddr, true, delay)
+	if err := startProxy(tunnelSiteHTTPSAddr, backendSSHAddr, true, delay); err != nil {
+		return err
+	}
 
 	// Tunnel: site proxy HTTP/3 (WAN delay) → backend SSH (campus delay)
 	tunnelSiteH3 := proxy.New(tunnelSiteH3Addr, backendSSHAddr, b.User, b.Pass, true)
 	go tunnelSiteH3.ListenAndServeH3()
 
 	// Tunnel: headend proxies (SSH frontend, campus delay) → site proxy over WAN
-	startHeadend := func(addr, backendURL, transport string, d time.Duration) {
+	startHeadend := func(addr, backendURL, transport string, d time.Duration) error {
 		ln, err := net.Listen("tcp", addr)
 		if err != nil {
-			log.Fatalf("listen %s: %v", addr, err)
+			return fmt.Errorf("listen %s: %w", addr, err)
 		}
 		srv, err := headend.New(addr, backendURL, b.User, b.Pass, transport)
 		if err != nil {
-			log.Fatalf("headend %s: %v", addr, err)
+			ln.Close()
+			return fmt.Errorf("headend %s: %w", addr, err)
 		}
 		srv.SetListener(wrapListener(ln, d))
 		go srv.ListenAndServe()
+		return nil
 	}
-	startHeadend(headendHTTPSAddr, fmt.Sprintf("https://%s", tunnelSiteHTTPSAddr), "https", campusDelay)
-	startHeadend(headendH3Addr, fmt.Sprintf("https://%s", tunnelSiteH3Addr), "http3", campusDelay)
+	if err := startHeadend(headendHTTPSAddr, fmt.Sprintf("https://%s", tunnelSiteHTTPSAddr), "https", campusDelay); err != nil {
+		return err
+	}
+	if err := startHeadend(headendH3Addr, fmt.Sprintf("https://%s", tunnelSiteH3Addr), "http3", campusDelay); err != nil {
+		return err
+	}
 
 	time.Sleep(500 * time.Millisecond)
 	log.Printf("Server ready — profile=%s, simulated RTT=%.0fms", b.Latency, rttMs)
@@ -198,6 +211,22 @@ func (b *BenchCmd) Run() error {
 			defer pc.Stop()
 			log.Printf("AF_PACKET: counting packets on ports %v", allPorts)
 		}
+	}
+
+	// Signal handler for clean shutdown — must be after all resource setup
+	// so it can clean up everything that defers would.
+	if !b.Userspace && delay > 0 {
+		sigCh := make(chan os.Signal, 1)
+		signal.Notify(sigCh, syscall.SIGINT, syscall.SIGTERM)
+		go func() {
+			<-sigCh
+			if pc != nil {
+				pc.Stop()
+			}
+			netem.Teardown()
+			os.Exit(0)
+		}()
+		defer signal.Stop(sigCh)
 	}
 
 	cfg := bench.Config{

--- a/internal/pktcount/extract.go
+++ b/internal/pktcount/extract.go
@@ -1,0 +1,26 @@
+package pktcount
+
+import "encoding/binary"
+
+// extractPorts reads src/dst ports from an IP packet (TCP or UDP).
+func extractPorts(ip []byte) (src, dst uint16, ok bool) {
+	if len(ip) < 20 {
+		return 0, 0, false
+	}
+	version := ip[0] >> 4
+	if version != 4 {
+		return 0, 0, false
+	}
+	ihl := int(ip[0]&0x0f) * 4
+	proto := ip[9]
+	if proto != 6 && proto != 17 { // TCP or UDP only
+		return 0, 0, false
+	}
+	if len(ip) < ihl+4 {
+		return 0, 0, false
+	}
+	transport := ip[ihl:]
+	src = binary.BigEndian.Uint16(transport[0:2])
+	dst = binary.BigEndian.Uint16(transport[2:4])
+	return src, dst, true
+}

--- a/internal/pktcount/pktcount.go
+++ b/internal/pktcount/pktcount.go
@@ -1,9 +1,10 @@
+//go:build linux
+
 // Package pktcount captures real packet counts on loopback using AF_PACKET.
 // Requires CAP_NET_RAW or root.
 package pktcount
 
 import (
-	"encoding/binary"
 	"sync"
 	"sync/atomic"
 	"syscall"
@@ -120,29 +121,6 @@ func (c *Counter) capture() {
 			c.out.Add(1)
 		}
 	}
-}
-
-// extractPorts reads src/dst ports from an IP packet (TCP or UDP).
-func extractPorts(ip []byte) (src, dst uint16, ok bool) {
-	if len(ip) < 20 {
-		return 0, 0, false
-	}
-	version := ip[0] >> 4
-	if version != 4 {
-		return 0, 0, false
-	}
-	ihl := int(ip[0]&0x0f) * 4
-	proto := ip[9]
-	if proto != 6 && proto != 17 { // TCP or UDP only
-		return 0, 0, false
-	}
-	if len(ip) < ihl+4 {
-		return 0, 0, false
-	}
-	transport := ip[ihl:]
-	src = binary.BigEndian.Uint16(transport[0:2])
-	dst = binary.BigEndian.Uint16(transport[2:4])
-	return src, dst, true
 }
 
 func htons(v uint16) uint16 {

--- a/internal/pktcount/pktcount_other.go
+++ b/internal/pktcount/pktcount_other.go
@@ -1,0 +1,25 @@
+//go:build !linux
+
+package pktcount
+
+import "fmt"
+
+// Counter is unavailable on non-Linux platforms.
+type Counter struct{}
+
+// New returns an error on non-Linux platforms.
+func New(ports []int) (*Counter, error) {
+	return nil, fmt.Errorf("AF_PACKET requires Linux")
+}
+
+// Start is a no-op on non-Linux.
+func (c *Counter) Start() {}
+
+// Snapshot returns zero on non-Linux.
+func (c *Counter) Snapshot() (in, out int) { return 0, 0 }
+
+// Reset is a no-op on non-Linux.
+func (c *Counter) Reset() {}
+
+// Stop is a no-op on non-Linux.
+func (c *Counter) Stop() {}

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -36,6 +36,7 @@ type Server struct {
 	listener    net.Listener
 	packetConn  net.PacketConn
 	srv         *http.Server
+	h3srv       *http3.Server
 }
 
 // New creates a proxy server. If pooled is true, one SSH connection
@@ -67,12 +68,26 @@ func (s *Server) Addr() string {
 	return ""
 }
 
-// Close stops the proxy server.
+// Close stops the proxy server and releases all resources.
 func (s *Server) Close() error {
-	if s.srv != nil {
-		return s.srv.Close()
+	var firstErr error
+	if s.h3srv != nil {
+		if err := s.h3srv.Close(); err != nil && firstErr == nil {
+			firstErr = err
+		}
 	}
-	return nil
+	if s.srv != nil {
+		if err := s.srv.Close(); err != nil && firstErr == nil {
+			firstErr = err
+		}
+	}
+	s.mu.Lock()
+	if s.pool != nil {
+		s.pool.Close()
+		s.pool = nil
+	}
+	s.mu.Unlock()
+	return firstErr
 }
 
 // ListenAndServeTLS starts the HTTPS proxy.
@@ -244,6 +259,7 @@ func (s *Server) ListenAndServeH3() error {
 		TLSConfig: tlsCfg,
 		QUICConfig: &quic.Config{Allow0RTT: true},
 	}
+	s.h3srv = h3srv
 
 	if s.packetConn == nil {
 		s.packetConn, err = net.ListenPacket("udp", s.addr)


### PR DESCRIPTION
Fixes 4 critical architecture issues identified in the full codebase review.

## What was broken

1. **pktcount cross-compilation** — `AF_PACKET` (Linux-only) had no build constraint. Release workflow cross-compiles for darwin/windows, producing binaries that would fail at runtime. Same class of bug that netem already handles correctly.

2. **`log.Fatalf` in server startup** — `startSSH`, `startHTTPS`, `startProxy`, `startHeadend` all called `log.Fatalf` on listen errors. `Fatalf` calls `os.Exit(1)`, which skips `defer netem.Teardown()` — leaving tc netem qdiscs on the host loopback interface. Requires manual `sudo tc qdisc del dev lo root` to recover.

3. **Signal handler missed packet counter** — SIGINT handler called `netem.Teardown()` + `os.Exit(0)`, but was created before the packet counter. The AF_PACKET socket leaked on Ctrl-C. Moved handler after all resource setup.

4. **Proxy `Close()` leaked resources** — only closed the HTTPS server. The HTTP/3 server, its UDP socket, and the pooled SSH connection all leaked. Goroutines and file descriptors accumulated in tests and standalone server mode.

## Changes

- `internal/pktcount/pktcount.go`: add `//go:build linux`
- `internal/pktcount/pktcount_other.go`: new stub for non-linux (matches netem pattern)
- `internal/pktcount/extract.go`: moved `extractPorts` here (no build tag, so unit tests run on all platforms)
- `cmd/clibench/bench.go`: all startup closures return errors instead of calling `log.Fatalf`; signal handler moved after pc setup, calls `pc.Stop()` + `netem.Teardown()`
- `internal/proxy/proxy.go`: `Close()` shuts down H3 server, HTTPS server, and pooled SSH; `h3srv` stored on struct

## Testing

All tests pass with `-race`, 0 lint issues. No new test files needed — these are all correctness fixes to existing code paths.