### PR TITLE
refactor: extract shared HTTP/SSH scaffolding, deduplicate bench

### DIFF
--- a/internal/bench/bench.go
+++ b/internal/bench/bench.go
@@ -111,36 +111,46 @@ func (c counters) iter() stats.IterCounts {
 	return stats.IterCounts{Trips: c.trips, Reads: c.reads, Writes: c.writes}
 }
 
+// sshFreshBench runs a fresh-connection SSH benchmark where each iteration
+// dials, executes commands, and closes. Used by SSH fresh-conn, batch-exec,
+// and tunnel modes.
+func sshFreshBench(c Config, addr string, cfg *ssh.ClientConfig, execFn func(*ssh.Client) error) ([]time.Duration, counters) {
+	cnt := newCounters(c.Iterations)
+	times := stats.RunParallel(c.Iterations, c.Concurrency, func(idx int) time.Duration {
+		start := time.Now()
+		conn, cc, err := sshDialCounted(addr, cfg)
+		if err != nil {
+			return errDuration
+		}
+		defer conn.Close()
+		if err := execFn(conn); err != nil {
+			return errDuration
+		}
+		cnt.recordConn(idx, cc)
+		return time.Since(start)
+	})
+	return times, cnt
+}
+
 // SSH runs all SSH benchmark modes and returns the results.
 func SSH(c Config) []stats.Result {
 	log.Printf("Benchmarking SSH (%d iterations, %d concurrency, %d cmds/iter)", c.Iterations, c.Concurrency, c.Commands)
 	cfg := sshConfig(c.User, c.Pass)
 
 	// Mode 1: fresh connection per iteration
-	freshC := newCounters(c.Iterations)
-	freshTimes := stats.RunParallel(c.Iterations, c.Concurrency, func(idx int) time.Duration {
-		start := time.Now()
-		conn, cc, err := sshDialCounted(c.Addr, cfg)
-		if err != nil {
-			log.Printf("ssh dial: %v", err)
-			return errDuration
-		}
-		defer conn.Close()
+	freshTimes, freshC := sshFreshBench(c, c.Addr, cfg, func(conn *ssh.Client) error {
 		for i := 0; i < c.Commands; i++ {
 			sess, err := conn.NewSession()
 			if err != nil {
-				log.Printf("ssh session: %v", err)
-				return errDuration
+				return err
 			}
 			_, err = sess.Output("show version")
 			sess.Close()
 			if err != nil {
-				log.Printf("ssh exec: %v", err)
-				return errDuration
+				return err
 			}
 		}
-		freshC.recordConn(idx, cc)
-		return time.Since(start)
+		return nil
 	})
 
 	// Mode 2: reuse one connection (ControlMaster-style)
@@ -185,28 +195,14 @@ func SSH(c Config) []stats.Result {
 
 	// Mode 3: batch exec
 	batchPayload := stats.GenerateExecPayload(c.Commands)
-	batchC := newCounters(c.Iterations)
-	batchTimes := stats.RunParallel(c.Iterations, c.Concurrency, func(idx int) time.Duration {
-		start := time.Now()
-		conn, cc, err := sshDialCounted(c.Addr, cfg)
-		if err != nil {
-			log.Printf("ssh batch dial: %v", err)
-			return errDuration
-		}
-		defer conn.Close()
+	batchTimes, batchC := sshFreshBench(c, c.Addr, cfg, func(conn *ssh.Client) error {
 		sess, err := conn.NewSession()
 		if err != nil {
-			log.Printf("ssh batch session: %v", err)
-			return errDuration
+			return err
 		}
 		_, err = sess.Output(batchPayload)
 		sess.Close()
-		if err != nil {
-			log.Printf("ssh batch exec: %v", err)
-			return errDuration
-		}
-		batchC.recordConn(idx, cc)
-		return time.Since(start)
+		return err
 	})
 
 	results := []stats.Result{
@@ -219,26 +215,13 @@ func SSH(c Config) []stats.Result {
 
 	// Mode 4: PTY/shell — fresh connection per iteration
 	prompt := c.Hostname + "#"
-	ptyFreshC := newCounters(c.Iterations)
-	ptyFreshTimes := stats.RunParallel(c.Iterations, c.Concurrency, func(idx int) time.Duration {
-		start := time.Now()
-		conn, cc, err := sshDialCounted(c.Addr, cfg)
-		if err != nil {
-			log.Printf("ssh pty dial: %v", err)
-			return errDuration
-		}
-		defer conn.Close()
+	ptyFreshTimes, ptyFreshC := sshFreshBench(c, c.Addr, cfg, func(conn *ssh.Client) error {
 		sess, err := conn.NewSession()
 		if err != nil {
-			return errDuration
+			return err
 		}
 		defer sess.Close()
-		if err := ptyExecCmds(sess, prompt, c.Commands); err != nil {
-			log.Printf("ssh pty-fresh: %v", err)
-			return errDuration
-		}
-		ptyFreshC.recordConn(idx, cc)
-		return time.Since(start)
+		return ptyExecCmds(sess, prompt, c.Commands)
 	})
 	results = append(results, stats.Summarize("ssh", "pty-fresh", c.Commands, c.Iterations, c.Concurrency, c.Profile, c.RTTms, ptyFreshTimes, ptyFreshC.iter()))
 

--- a/internal/bench/tunnel.go
+++ b/internal/bench/tunnel.go
@@ -2,7 +2,6 @@ package bench
 
 import (
 	"log"
-	"time"
 
 	"github.com/lykinsbd/clibench/internal/stats"
 	"golang.org/x/crypto/ssh"
@@ -21,72 +20,45 @@ func Tunnel(c TunnelConfig) []stats.Result {
 	cfg := sshConfig(c.User, c.Pass)
 
 	var results []stats.Result
-
 	if c.HTTPSHeadendAddr != "" {
-		results = append(results, tunnelFresh(cfg, c, c.HTTPSHeadendAddr, "tunnel", "ssh-https-ssh")...)
+		results = append(results, tunnelModes(c, cfg, c.HTTPSHeadendAddr, "ssh-https-ssh")...)
 	}
 	if c.H3HeadendAddr != "" {
-		results = append(results, tunnelFresh(cfg, c, c.H3HeadendAddr, "tunnel", "ssh-http3-ssh")...)
+		results = append(results, tunnelModes(c, cfg, c.H3HeadendAddr, "ssh-http3-ssh")...)
 	}
-
 	return results
 }
 
-func tunnelFresh(cfg *ssh.ClientConfig, c TunnelConfig, edgeAddr, transport, op string) []stats.Result {
+func tunnelModes(c TunnelConfig, cfg *ssh.ClientConfig, addr, op string) []stats.Result {
 	batchPayload := stats.GenerateExecPayload(c.Commands)
 
-	freshC := newCounters(c.Iterations)
-	freshTimes := stats.RunParallel(c.Iterations, c.Concurrency, func(idx int) time.Duration {
-		start := time.Now()
-		conn, cc, err := sshDialCounted(edgeAddr, cfg)
-		if err != nil {
-			log.Printf("%s fresh: %v", op, err)
-			return errDuration
-		}
-		defer conn.Close()
+	freshTimes, freshC := sshFreshBench(c.Config, addr, cfg, func(conn *ssh.Client) error {
 		for i := 0; i < c.Commands; i++ {
 			sess, err := conn.NewSession()
 			if err != nil {
-				log.Printf("%s session: %v", op, err)
-				return errDuration
+				return err
 			}
 			_, err = sess.Output("show version")
 			sess.Close()
 			if err != nil {
-				log.Printf("%s exec: %v", op, err)
-				return errDuration
+				return err
 			}
 		}
-		freshC.recordConn(idx, cc)
-		return time.Since(start)
+		return nil
 	})
 
-	batchC := newCounters(c.Iterations)
-	batchTimes := stats.RunParallel(c.Iterations, c.Concurrency, func(idx int) time.Duration {
-		start := time.Now()
-		conn, cc, err := sshDialCounted(edgeAddr, cfg)
-		if err != nil {
-			log.Printf("%s-batch: %v", op, err)
-			return errDuration
-		}
-		defer conn.Close()
+	batchTimes, batchC := sshFreshBench(c.Config, addr, cfg, func(conn *ssh.Client) error {
 		sess, err := conn.NewSession()
 		if err != nil {
-			log.Printf("%s-batch session: %v", op, err)
-			return errDuration
+			return err
 		}
 		_, err = sess.Output(batchPayload)
 		sess.Close()
-		if err != nil {
-			log.Printf("%s-batch exec: %v", op, err)
-			return errDuration
-		}
-		batchC.recordConn(idx, cc)
-		return time.Since(start)
+		return err
 	})
 
 	return []stats.Result{
-		stats.Summarize(transport, op, c.Commands, c.Iterations, c.Concurrency, c.Profile, c.RTTms, freshTimes, freshC.iter()),
-		stats.Summarize(transport, op+"-batch", c.Commands, c.Iterations, c.Concurrency, c.Profile, c.RTTms, batchTimes, batchC.iter()),
+		stats.Summarize("tunnel", op, c.Commands, c.Iterations, c.Concurrency, c.Profile, c.RTTms, freshTimes, freshC.iter()),
+		stats.Summarize("tunnel", op+"-batch", c.Commands, c.Iterations, c.Concurrency, c.Profile, c.RTTms, batchTimes, batchC.iter()),
 	}
 }

--- a/internal/headend/headend.go
+++ b/internal/headend/headend.go
@@ -5,13 +5,9 @@
 package headend
 
 import (
-	"crypto/ed25519"
-	"crypto/rand"
 	"crypto/tls"
-	"errors"
 	"fmt"
 	"io"
-	"log"
 	"net"
 	"net/http"
 	"strings"
@@ -19,6 +15,8 @@ import (
 
 	"github.com/quic-go/quic-go/http3"
 	"golang.org/x/crypto/ssh"
+
+	"github.com/lykinsbd/clibench/internal/sshutil"
 )
 
 // Server is an SSH server that forwards commands via HTTP to a site proxy.
@@ -32,28 +30,13 @@ type Server struct {
 	listener   net.Listener
 }
 
-// New creates an edge proxy. Transport is "https" or "http3".
+// New creates a headend proxy. Transport is "https" or "http3".
 func New(addr, backendURL, user, pass, transport string) (*Server, error) {
-	_, priv, err := ed25519.GenerateKey(rand.Reader)
-	if err != nil {
-		return nil, err
-	}
-	signer, err := ssh.NewSignerFromKey(priv)
+	cfg, err := sshutil.ServerConfig(user, pass)
 	if err != nil {
 		return nil, err
 	}
 
-	sshCfg := &ssh.ServerConfig{
-		PasswordCallback: func(c ssh.ConnMetadata, p []byte) (*ssh.Permissions, error) {
-			if c.User() == user && string(p) == pass {
-				return nil, nil
-			}
-			return nil, fmt.Errorf("auth failed")
-		},
-	}
-	sshCfg.AddHostKey(signer)
-
-	tlsCfg := &tls.Config{InsecureSkipVerify: true}
 	var rt http.RoundTripper
 	if transport == "http3" {
 		rt = &http3.Transport{
@@ -63,7 +46,7 @@ func New(addr, backendURL, user, pass, transport string) (*Server, error) {
 			},
 		}
 	} else {
-		rt = &http.Transport{TLSClientConfig: tlsCfg}
+		rt = &http.Transport{TLSClientConfig: &tls.Config{InsecureSkipVerify: true}}
 	}
 
 	return &Server{
@@ -71,7 +54,7 @@ func New(addr, backendURL, user, pass, transport string) (*Server, error) {
 		backendURL: backendURL,
 		user:       user,
 		pass:       pass,
-		cfg:        sshCfg,
+		cfg:        cfg,
 		client:     &http.Client{Transport: rt, Timeout: 30 * time.Second},
 	}, nil
 }
@@ -97,46 +80,12 @@ func (s *Server) Close() error {
 
 // ListenAndServe starts accepting SSH connections.
 func (s *Server) ListenAndServe() error {
-	if s.listener == nil {
-		ln, err := net.Listen("tcp", s.addr)
-		if err != nil {
-			return err
-		}
-		s.listener = ln
-	}
-	log.Printf("Edge proxy SSH on %s → %s", s.listener.Addr(), s.backendURL)
-	for {
-		conn, err := s.listener.Accept()
-		if err != nil {
-			if errors.Is(err, net.ErrClosed) {
-				return nil
-			}
-			return err
-		}
-		go s.handleConn(conn)
-	}
-}
-
-func (s *Server) handleConn(c net.Conn) {
-	defer c.Close()
-	sConn, chans, reqs, err := ssh.NewServerConn(c, s.cfg)
+	var err error
+	s.listener, err = sshutil.Listen(s.listener, s.addr, "Headend SSH")
 	if err != nil {
-		return
+		return err
 	}
-	defer sConn.Close()
-	go ssh.DiscardRequests(reqs)
-
-	for newCh := range chans {
-		if newCh.ChannelType() != "session" {
-			newCh.Reject(ssh.UnknownChannelType, "unsupported")
-			continue
-		}
-		ch, requests, err := newCh.Accept()
-		if err != nil {
-			continue
-		}
-		go s.handleSession(ch, requests)
-	}
+	return sshutil.Serve(s.listener, s.cfg, s.handleSession)
 }
 
 func (s *Server) handleSession(ch ssh.Channel, reqs <-chan *ssh.Request) {
@@ -167,7 +116,6 @@ func (s *Server) handleSession(ch ssh.Channel, reqs <-chan *ssh.Request) {
 func (s *Server) forward(payload string) (string, error) {
 	lines := strings.Split(strings.TrimSpace(payload), "\n")
 	if len(lines) == 1 {
-		// Single command → GET /admin/exec/
 		cmd := strings.ReplaceAll(strings.TrimSpace(lines[0]), " ", "+")
 		url := fmt.Sprintf("%s/admin/exec/%s", s.backendURL, cmd)
 		req, err := http.NewRequest("GET", url, nil)
@@ -186,7 +134,6 @@ func (s *Server) forward(payload string) (string, error) {
 		}
 		return string(body), nil
 	}
-	// Multi-line → POST /admin/config
 	url := fmt.Sprintf("%s/admin/config", s.backendURL)
 	req, err := http.NewRequest("POST", url, strings.NewReader(payload))
 	if err != nil {

--- a/internal/http3server/server.go
+++ b/internal/http3server/server.go
@@ -1,20 +1,30 @@
 // Package http3server provides an HTTP/3 (QUIC) server that reuses the
-// httpserver handler logic. Same ASA-style endpoints, different transport.
+// httphandler logic. Same ASA-style endpoints, different transport.
 package http3server
 
 import (
-	"io"
 	"log"
 	"net"
-	"net/http"
 	"strings"
 
 	"github.com/quic-go/quic-go"
 	"github.com/quic-go/quic-go/http3"
 
 	"github.com/lykinsbd/clibench/internal/device"
+	"github.com/lykinsbd/clibench/internal/httphandler"
 	"github.com/lykinsbd/clibench/internal/tlsutil"
 )
+
+// deviceRunner adapts *device.Device to httphandler.Runner.
+type deviceRunner struct{ dev *device.Device }
+
+func (d deviceRunner) RunCommands(cmds []string) (string, error) {
+	var out strings.Builder
+	for _, cmd := range cmds {
+		out.WriteString(d.dev.Exec(cmd))
+	}
+	return out.String(), nil
+}
 
 // Server is an HTTP/3 server backed by a Device.
 type Server struct {
@@ -30,9 +40,7 @@ func New(addr string, dev *device.Device) *Server {
 }
 
 // SetPacketConn sets a custom net.PacketConn for the server.
-func (s *Server) SetPacketConn(conn net.PacketConn) {
-	s.conn = conn
-}
+func (s *Server) SetPacketConn(conn net.PacketConn) { s.conn = conn }
 
 // Addr returns the listener's address, or "" if not yet listening.
 func (s *Server) Addr() string {
@@ -58,16 +66,11 @@ func (s *Server) ListenAndServe() error {
 	}
 	tlsCfg.NextProtos = []string{http3.NextProtoH3}
 
-	mux := http.NewServeMux()
-	mux.HandleFunc("/admin/exec/", s.handleExec)
-	mux.HandleFunc("/admin/config", s.handleConfig)
-
+	handler := httphandler.Mux(s.dev.Username, s.dev.Password, deviceRunner{s.dev})
 	s.srv = &http3.Server{
-		Handler:   s.authMiddleware(mux),
-		TLSConfig: tlsCfg,
-		QUICConfig: &quic.Config{
-			Allow0RTT: true,
-		},
+		Handler:    handler,
+		TLSConfig:  tlsCfg,
+		QUICConfig: &quic.Config{Allow0RTT: true},
 	}
 
 	if s.conn == nil {
@@ -78,64 +81,4 @@ func (s *Server) ListenAndServe() error {
 	}
 	log.Printf("HTTP/3 listening on %s", s.conn.LocalAddr())
 	return s.srv.Serve(s.conn)
-}
-
-func (s *Server) authMiddleware(next http.Handler) http.Handler {
-	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		user, pass, ok := r.BasicAuth()
-		if !ok || user != s.dev.Username || pass != s.dev.Password {
-			w.Header().Set("WWW-Authenticate", `Basic realm="device"`)
-			http.Error(w, "Unauthorized", http.StatusUnauthorized)
-			return
-		}
-		next.ServeHTTP(w, r)
-	})
-}
-
-func (s *Server) handleExec(w http.ResponseWriter, r *http.Request) {
-	path := strings.TrimPrefix(r.URL.Path, "/admin/exec/")
-	if path == "" {
-		http.Error(w, "no command", http.StatusBadRequest)
-		return
-	}
-	parts := strings.Split(path, "/")
-	var out strings.Builder
-	for _, p := range parts {
-		cmd := strings.ReplaceAll(p, "+", " ")
-		cmd = strings.TrimSpace(cmd)
-		if cmd == "" {
-			continue
-		}
-		out.WriteString(s.dev.Exec(cmd))
-	}
-	w.Header().Set("Content-Type", "text/plain")
-	io.WriteString(w, out.String())
-}
-
-func (s *Server) handleConfig(w http.ResponseWriter, r *http.Request) {
-	if r.Method != http.MethodPost {
-		http.Error(w, "POST required", http.StatusMethodNotAllowed)
-		return
-	}
-	body := make([]byte, 0, 1024)
-	buf := make([]byte, 1024)
-	for {
-		n, err := r.Body.Read(buf)
-		body = append(body, buf[:n]...)
-		if err != nil {
-			break
-		}
-	}
-	r.Body.Close()
-
-	var out strings.Builder
-	for _, line := range strings.Split(string(body), "\n") {
-		cmd := strings.TrimSpace(line)
-		if cmd == "" {
-			continue
-		}
-		out.WriteString(s.dev.Exec(cmd))
-	}
-	w.Header().Set("Content-Type", "text/plain")
-	io.WriteString(w, out.String())
 }

--- a/internal/httphandler/handler.go
+++ b/internal/httphandler/handler.go
@@ -1,0 +1,88 @@
+// Package httphandler provides shared HTTP handlers for the ASA-style
+// CLI interface used by httpserver, http3server, and proxy.
+package httphandler
+
+import (
+	"io"
+	"net/http"
+	"strings"
+)
+
+// Runner executes CLI commands and returns their output.
+type Runner interface {
+	RunCommands(cmds []string) (string, error)
+}
+
+// Mux returns an http.Handler with /admin/exec/ and /admin/config routes,
+// protected by basic auth.
+func Mux(user, pass string, r Runner) http.Handler {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/admin/exec/", execHandler(r))
+	mux.HandleFunc("/admin/config", configHandler(r))
+	return authMiddleware(user, pass, mux)
+}
+
+func authMiddleware(user, pass string, next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		u, p, ok := r.BasicAuth()
+		if !ok || u != user || p != pass {
+			w.Header().Set("WWW-Authenticate", `Basic realm="device"`)
+			http.Error(w, "Unauthorized", http.StatusUnauthorized)
+			return
+		}
+		next.ServeHTTP(w, r)
+	})
+}
+
+func execHandler(r Runner) http.HandlerFunc {
+	return func(w http.ResponseWriter, req *http.Request) {
+		path := strings.TrimPrefix(req.URL.Path, "/admin/exec/")
+		if path == "" {
+			http.Error(w, "no command", http.StatusBadRequest)
+			return
+		}
+		var cmds []string
+		for _, p := range strings.Split(path, "/") {
+			cmd := strings.TrimSpace(strings.ReplaceAll(p, "+", " "))
+			if cmd != "" {
+				cmds = append(cmds, cmd)
+			}
+		}
+		out, err := r.RunCommands(cmds)
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusBadGateway)
+			return
+		}
+		w.Header().Set("Content-Type", "text/plain")
+		io.WriteString(w, out)
+	}
+}
+
+func configHandler(r Runner) http.HandlerFunc {
+	return func(w http.ResponseWriter, req *http.Request) {
+		if req.Method != http.MethodPost {
+			http.Error(w, "POST required", http.StatusMethodNotAllowed)
+			return
+		}
+		body, err := io.ReadAll(req.Body)
+		req.Body.Close()
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusBadRequest)
+			return
+		}
+		var cmds []string
+		for _, line := range strings.Split(string(body), "\n") {
+			cmd := strings.TrimSpace(line)
+			if cmd != "" {
+				cmds = append(cmds, cmd)
+			}
+		}
+		out, err := r.RunCommands(cmds)
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusBadGateway)
+			return
+		}
+		w.Header().Set("Content-Type", "text/plain")
+		io.WriteString(w, out)
+	}
+}

--- a/internal/httpserver/server.go
+++ b/internal/httpserver/server.go
@@ -11,15 +11,26 @@ package httpserver
 import (
 	"crypto/tls"
 	"errors"
-	"io"
 	"log"
 	"net"
 	"net/http"
 	"strings"
 
 	"github.com/lykinsbd/clibench/internal/device"
+	"github.com/lykinsbd/clibench/internal/httphandler"
 	"github.com/lykinsbd/clibench/internal/tlsutil"
 )
+
+// deviceRunner adapts *device.Device to httphandler.Runner.
+type deviceRunner struct{ dev *device.Device }
+
+func (d deviceRunner) RunCommands(cmds []string) (string, error) {
+	var out strings.Builder
+	for _, cmd := range cmds {
+		out.WriteString(d.dev.Exec(cmd))
+	}
+	return out.String(), nil
+}
 
 // Server is an HTTPS server backed by a Device.
 type Server struct {
@@ -35,9 +46,7 @@ func New(addr string, dev *device.Device) *Server {
 }
 
 // SetListener sets a custom net.Listener (e.g., one wrapped with latency injection).
-func (s *Server) SetListener(ln net.Listener) {
-	s.listener = ln
-}
+func (s *Server) SetListener(ln net.Listener) { s.listener = ln }
 
 // Addr returns the listener's address, or "" if not yet listening.
 func (s *Server) Addr() string {
@@ -63,14 +72,8 @@ func (s *Server) ListenAndServeTLS() error {
 		return err
 	}
 
-	mux := http.NewServeMux()
-	mux.HandleFunc("/admin/exec/", s.handleExec)
-	mux.HandleFunc("/admin/config", s.handleConfig)
-
-	s.srv = &http.Server{
-		Handler:   s.authMiddleware(mux),
-		TLSConfig: tlsCfg,
-	}
+	handler := httphandler.Mux(s.dev.Username, s.dev.Password, deviceRunner{s.dev})
+	s.srv = &http.Server{Handler: handler, TLSConfig: tlsCfg}
 
 	if s.listener == nil {
 		s.listener, err = net.Listen("tcp", s.addr)
@@ -86,65 +89,3 @@ func (s *Server) ListenAndServeTLS() error {
 	}
 	return err
 }
-
-func (s *Server) authMiddleware(next http.Handler) http.Handler {
-	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		user, pass, ok := r.BasicAuth()
-		if !ok || user != s.dev.Username || pass != s.dev.Password {
-			w.Header().Set("WWW-Authenticate", `Basic realm="device"`)
-			http.Error(w, "Unauthorized", http.StatusUnauthorized)
-			return
-		}
-		next.ServeHTTP(w, r)
-	})
-}
-
-// handleExec handles GET /admin/exec/show+version or /admin/exec/cmd1/cmd2
-func (s *Server) handleExec(w http.ResponseWriter, r *http.Request) {
-	path := strings.TrimPrefix(r.URL.Path, "/admin/exec/")
-	if path == "" {
-		http.Error(w, "no command", http.StatusBadRequest)
-		return
-	}
-
-	// Split on "/" for multi-command support (ASA style)
-	parts := strings.Split(path, "/")
-	var out strings.Builder
-	for _, p := range parts {
-		cmd := strings.ReplaceAll(p, "+", " ")
-		cmd = strings.TrimSpace(cmd)
-		if cmd == "" {
-			continue
-		}
-		out.WriteString(s.dev.Exec(cmd))
-	}
-	w.Header().Set("Content-Type", "text/plain")
-	io.WriteString(w, out.String())
-}
-
-// handleConfig handles POST /admin/config with newline-delimited commands.
-func (s *Server) handleConfig(w http.ResponseWriter, r *http.Request) {
-	if r.Method != http.MethodPost {
-		http.Error(w, "POST required", http.StatusMethodNotAllowed)
-		return
-	}
-	body, err := io.ReadAll(r.Body)
-	r.Body.Close()
-	if err != nil {
-		http.Error(w, err.Error(), http.StatusBadRequest)
-		return
-	}
-
-	var out strings.Builder
-	for _, line := range strings.Split(string(body), "\n") {
-		cmd := strings.TrimSpace(line)
-		if cmd == "" {
-			continue
-		}
-		out.WriteString(s.dev.Exec(cmd))
-	}
-	w.Header().Set("Content-Type", "text/plain")
-	io.WriteString(w, out.String())
-}
-
-

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -1,5 +1,5 @@
-// Package proxy provides an HTTPS server that forwards CLI commands
-// to a backend network device over SSH. This is the "edge proxy" pattern:
+// Package proxy provides an HTTPS/HTTP3 server that forwards CLI commands
+// to a backend network device over SSH. This is the "site proxy" pattern:
 // automation talks HTTPS over the WAN, the proxy talks SSH over a
 // low-latency campus link.
 package proxy
@@ -8,7 +8,6 @@ import (
 	"crypto/tls"
 	"errors"
 	"fmt"
-	"io"
 	"log"
 	"net"
 	"net/http"
@@ -16,6 +15,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/lykinsbd/clibench/internal/httphandler"
 	"github.com/lykinsbd/clibench/internal/tlsutil"
 	"golang.org/x/crypto/ssh"
 
@@ -90,72 +90,8 @@ func (s *Server) Close() error {
 	return firstErr
 }
 
-// ListenAndServeTLS starts the HTTPS proxy.
-// It returns nil when the server is closed via Close().
-func (s *Server) ListenAndServeTLS() error {
-	tlsCfg, err := tlsutil.SelfSignedConfig()
-	if err != nil {
-		return err
-	}
-	mux := http.NewServeMux()
-	mux.HandleFunc("/admin/exec/", s.handleExec)
-	mux.HandleFunc("/admin/config", s.handleConfig)
-
-	if s.listener == nil {
-		s.listener, err = net.Listen("tcp", s.addr)
-		if err != nil {
-			return err
-		}
-	}
-	ln := tls.NewListener(s.listener, tlsCfg)
-	s.srv = &http.Server{Handler: s.authMiddleware(mux), TLSConfig: tlsCfg}
-	log.Printf("Proxy HTTPS listening on %s → SSH backend %s (pooled=%v)", s.listener.Addr(), s.backendAddr, s.pooled)
-	err = s.srv.Serve(ln)
-	if errors.Is(err, http.ErrServerClosed) {
-		return nil
-	}
-	return err
-}
-
-func (s *Server) authMiddleware(next http.Handler) http.Handler {
-	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		user, pass, ok := r.BasicAuth()
-		if !ok || user != s.user || pass != s.pass {
-			w.Header().Set("WWW-Authenticate", `Basic realm="proxy"`)
-			http.Error(w, "Unauthorized", http.StatusUnauthorized)
-			return
-		}
-		next.ServeHTTP(w, r)
-	})
-}
-
-func (s *Server) getSSH() (*ssh.Client, bool, error) {
-	if !s.pooled {
-		c, err := ssh.Dial("tcp", s.backendAddr, s.sshCfg)
-		return c, false, err
-	}
-	// Caller must hold s.mu when using the pooled connection.
-	if s.pool != nil {
-		return s.pool, true, nil
-	}
-	c, err := ssh.Dial("tcp", s.backendAddr, s.sshCfg)
-	if err != nil {
-		return nil, false, err
-	}
-	s.pool = c
-	return c, true, nil
-}
-
-// resetPool clears the pooled connection so the next call reconnects.
-// Caller must hold s.mu.
-func (s *Server) resetPool() {
-	if s.pool != nil {
-		s.pool.Close()
-		s.pool = nil
-	}
-}
-
-func (s *Server) execSSH(commands []string) (string, error) {
+// RunCommands implements httphandler.Runner by forwarding to SSH backend.
+func (s *Server) RunCommands(cmds []string) (string, error) {
 	if s.pooled {
 		s.mu.Lock()
 		defer s.mu.Unlock()
@@ -170,7 +106,7 @@ func (s *Server) execSSH(commands []string) (string, error) {
 	}
 
 	var out strings.Builder
-	for _, cmd := range commands {
+	for _, cmd := range cmds {
 		sess, err := conn.NewSession()
 		if err != nil {
 			if pooled {
@@ -191,52 +127,29 @@ func (s *Server) execSSH(commands []string) (string, error) {
 	return out.String(), nil
 }
 
-func (s *Server) handleExec(w http.ResponseWriter, r *http.Request) {
-	path := strings.TrimPrefix(r.URL.Path, "/admin/exec/")
-	if path == "" {
-		http.Error(w, "no command", http.StatusBadRequest)
-		return
-	}
-	var cmds []string
-	for _, p := range strings.Split(path, "/") {
-		cmd := strings.TrimSpace(strings.ReplaceAll(p, "+", " "))
-		if cmd != "" {
-			cmds = append(cmds, cmd)
-		}
-	}
-	out, err := s.execSSH(cmds)
+// ListenAndServeTLS starts the HTTPS proxy.
+func (s *Server) ListenAndServeTLS() error {
+	tlsCfg, err := tlsutil.SelfSignedConfig()
 	if err != nil {
-		http.Error(w, err.Error(), http.StatusBadGateway)
-		return
+		return err
 	}
-	w.Header().Set("Content-Type", "text/plain")
-	io.WriteString(w, out)
-}
 
-func (s *Server) handleConfig(w http.ResponseWriter, r *http.Request) {
-	if r.Method != http.MethodPost {
-		http.Error(w, "POST required", http.StatusMethodNotAllowed)
-		return
-	}
-	body, err := io.ReadAll(r.Body)
-	if err != nil {
-		http.Error(w, err.Error(), http.StatusBadRequest)
-		return
-	}
-	var cmds []string
-	for _, line := range strings.Split(string(body), "\n") {
-		cmd := strings.TrimSpace(line)
-		if cmd != "" {
-			cmds = append(cmds, cmd)
+	handler := httphandler.Mux(s.user, s.pass, s)
+
+	if s.listener == nil {
+		s.listener, err = net.Listen("tcp", s.addr)
+		if err != nil {
+			return err
 		}
 	}
-	out, err := s.execSSH(cmds)
-	if err != nil {
-		http.Error(w, err.Error(), http.StatusBadGateway)
-		return
+	ln := tls.NewListener(s.listener, tlsCfg)
+	s.srv = &http.Server{Handler: handler, TLSConfig: tlsCfg}
+	log.Printf("Proxy HTTPS listening on %s → SSH backend %s (pooled=%v)", s.listener.Addr(), s.backendAddr, s.pooled)
+	err = s.srv.Serve(ln)
+	if errors.Is(err, http.ErrServerClosed) {
+		return nil
 	}
-	w.Header().Set("Content-Type", "text/plain")
-	io.WriteString(w, out)
+	return err
 }
 
 // SetPacketConn sets a custom net.PacketConn for HTTP/3 serving.
@@ -250,16 +163,12 @@ func (s *Server) ListenAndServeH3() error {
 	}
 	tlsCfg.NextProtos = []string{"h3"}
 
-	mux := http.NewServeMux()
-	mux.HandleFunc("/admin/exec/", s.handleExec)
-	mux.HandleFunc("/admin/config", s.handleConfig)
-
-	h3srv := &http3.Server{
-		Handler:   s.authMiddleware(mux),
-		TLSConfig: tlsCfg,
+	handler := httphandler.Mux(s.user, s.pass, s)
+	s.h3srv = &http3.Server{
+		Handler:    handler,
+		TLSConfig:  tlsCfg,
 		QUICConfig: &quic.Config{Allow0RTT: true},
 	}
-	s.h3srv = h3srv
 
 	if s.packetConn == nil {
 		s.packetConn, err = net.ListenPacket("udp", s.addr)
@@ -268,5 +177,28 @@ func (s *Server) ListenAndServeH3() error {
 		}
 	}
 	log.Printf("Proxy HTTP/3 listening on %s → SSH backend %s (pooled=%v)", s.packetConn.LocalAddr(), s.backendAddr, s.pooled)
-	return h3srv.Serve(s.packetConn)
+	return s.h3srv.Serve(s.packetConn)
+}
+
+func (s *Server) getSSH() (*ssh.Client, bool, error) {
+	if !s.pooled {
+		c, err := ssh.Dial("tcp", s.backendAddr, s.sshCfg)
+		return c, false, err
+	}
+	if s.pool != nil {
+		return s.pool, true, nil
+	}
+	c, err := ssh.Dial("tcp", s.backendAddr, s.sshCfg)
+	if err != nil {
+		return nil, false, err
+	}
+	s.pool = c
+	return c, true, nil
+}
+
+func (s *Server) resetPool() {
+	if s.pool != nil {
+		s.pool.Close()
+		s.pool = nil
+	}
 }

--- a/internal/sshserver/server.go
+++ b/internal/sshserver/server.go
@@ -3,16 +3,12 @@
 package sshserver
 
 import (
-	"crypto/ed25519"
-	"crypto/rand"
-	"errors"
-	"fmt"
 	"io"
-	"log"
 	"net"
 	"strings"
 
 	"github.com/lykinsbd/clibench/internal/device"
+	"github.com/lykinsbd/clibench/internal/sshutil"
 	"golang.org/x/crypto/ssh"
 )
 
@@ -26,32 +22,15 @@ type Server struct {
 
 // New creates an SSH server on addr backed by dev.
 func New(addr string, dev *device.Device) (*Server, error) {
-	_, priv, err := ed25519.GenerateKey(rand.Reader)
+	cfg, err := sshutil.ServerConfig(dev.Username, dev.Password)
 	if err != nil {
 		return nil, err
 	}
-	signer, err := ssh.NewSignerFromKey(priv)
-	if err != nil {
-		return nil, err
-	}
-
-	cfg := &ssh.ServerConfig{
-		PasswordCallback: func(c ssh.ConnMetadata, pass []byte) (*ssh.Permissions, error) {
-			if c.User() == dev.Username && string(pass) == dev.Password {
-				return nil, nil
-			}
-			return nil, fmt.Errorf("auth failed")
-		},
-	}
-	cfg.AddHostKey(signer)
-
 	return &Server{dev: dev, cfg: cfg, addr: addr}, nil
 }
 
 // SetListener sets a custom net.Listener (e.g., one wrapped with latency injection).
-func (s *Server) SetListener(ln net.Listener) {
-	s.listener = ln
-}
+func (s *Server) SetListener(ln net.Listener) { s.listener = ln }
 
 // Addr returns the listener's address, or "" if not yet listening.
 func (s *Server) Addr() string {
@@ -70,48 +49,13 @@ func (s *Server) Close() error {
 }
 
 // ListenAndServe starts accepting SSH connections.
-// It returns nil when the listener is closed via Close().
 func (s *Server) ListenAndServe() error {
-	if s.listener == nil {
-		ln, err := net.Listen("tcp", s.addr)
-		if err != nil {
-			return err
-		}
-		s.listener = ln
-	}
-	log.Printf("SSH listening on %s", s.listener.Addr())
-	for {
-		conn, err := s.listener.Accept()
-		if err != nil {
-			if errors.Is(err, net.ErrClosed) {
-				return nil
-			}
-			return err
-		}
-		go s.handleConn(conn)
-	}
-}
-
-func (s *Server) handleConn(c net.Conn) {
-	defer c.Close()
-	sConn, chans, reqs, err := ssh.NewServerConn(c, s.cfg)
+	var err error
+	s.listener, err = sshutil.Listen(s.listener, s.addr, "SSH")
 	if err != nil {
-		return
+		return err
 	}
-	defer sConn.Close()
-	go ssh.DiscardRequests(reqs)
-
-	for newCh := range chans {
-		if newCh.ChannelType() != "session" {
-			newCh.Reject(ssh.UnknownChannelType, "unsupported")
-			continue
-		}
-		ch, requests, err := newCh.Accept()
-		if err != nil {
-			continue
-		}
-		go s.handleSession(ch, requests)
-	}
+	return sshutil.Serve(s.listener, s.cfg, s.handleSession)
 }
 
 func (s *Server) handleSession(ch ssh.Channel, reqs <-chan *ssh.Request) {
@@ -132,7 +76,6 @@ func (s *Server) handleSession(ch ssh.Channel, reqs <-chan *ssh.Request) {
 			}
 			req.Reply(true, nil)
 			if execCmd != "" {
-				// Split newline-delimited payloads (batch exec mode)
 				var out strings.Builder
 				for _, line := range strings.Split(execCmd, "\n") {
 					cmd := strings.TrimSpace(line)

--- a/internal/sshutil/sshutil.go
+++ b/internal/sshutil/sshutil.go
@@ -1,0 +1,91 @@
+// Package sshutil provides shared SSH server scaffolding used by
+// sshserver and headend.
+package sshutil
+
+import (
+	"crypto/ed25519"
+	"crypto/rand"
+	"errors"
+	"fmt"
+	"log"
+	"net"
+
+	"golang.org/x/crypto/ssh"
+)
+
+// SessionHandler is called for each accepted session channel.
+type SessionHandler func(ch ssh.Channel, reqs <-chan *ssh.Request)
+
+// ServerConfig creates an ssh.ServerConfig with ed25519 host key and
+// password authentication.
+func ServerConfig(user, pass string) (*ssh.ServerConfig, error) {
+	_, priv, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		return nil, err
+	}
+	signer, err := ssh.NewSignerFromKey(priv)
+	if err != nil {
+		return nil, err
+	}
+	cfg := &ssh.ServerConfig{
+		PasswordCallback: func(c ssh.ConnMetadata, p []byte) (*ssh.Permissions, error) {
+			if c.User() == user && string(p) == pass {
+				return nil, nil
+			}
+			return nil, fmt.Errorf("auth failed")
+		},
+	}
+	cfg.AddHostKey(signer)
+	return cfg, nil
+}
+
+// Serve accepts connections on ln and dispatches sessions to handler.
+// Returns nil when ln is closed.
+func Serve(ln net.Listener, cfg *ssh.ServerConfig, handler SessionHandler) error {
+	for {
+		conn, err := ln.Accept()
+		if err != nil {
+			if errors.Is(err, net.ErrClosed) {
+				return nil
+			}
+			return err
+		}
+		go handleConn(conn, cfg, handler)
+	}
+}
+
+func handleConn(c net.Conn, cfg *ssh.ServerConfig, handler SessionHandler) {
+	defer c.Close()
+	sConn, chans, reqs, err := ssh.NewServerConn(c, cfg)
+	if err != nil {
+		return
+	}
+	defer sConn.Close()
+	go ssh.DiscardRequests(reqs)
+
+	for newCh := range chans {
+		if newCh.ChannelType() != "session" {
+			newCh.Reject(ssh.UnknownChannelType, "unsupported")
+			continue
+		}
+		ch, requests, err := newCh.Accept()
+		if err != nil {
+			continue
+		}
+		go handler(ch, requests)
+	}
+}
+
+// Listen creates a listener and logs the address. If ln is non-nil, uses it.
+func Listen(ln net.Listener, addr, label string) (net.Listener, error) {
+	if ln != nil {
+		log.Printf("%s listening on %s", label, ln.Addr())
+		return ln, nil
+	}
+	l, err := net.Listen("tcp", addr)
+	if err != nil {
+		return nil, err
+	}
+	log.Printf("%s listening on %s", label, l.Addr())
+	return l, nil
+}


### PR DESCRIPTION
P1 architecture improvements from the full codebase review. Eliminates ~200 lines of duplication and makes adding new protocols trivial.

## Changes

### New packages

- **`internal/httphandler`** — `Runner` interface + `Mux(user, pass, runner)` providing shared `handleExec`, `handleConfig`, `authMiddleware`. One place to maintain the ASA-style HTTP API.

- **`internal/sshutil`** — `ServerConfig(user, pass)`, `Serve(ln, cfg, handler)`, `Listen(ln, addr, label)`, `SessionHandler` type. One place for SSH server scaffolding.

### Refactored packages

| Package | Before | After | Savings |
|---------|--------|-------|---------|
| httpserver | 120 lines | 91 lines | -29 |
| http3server | 130 lines | 84 lines | -46 |
| proxy | 230 lines | 204 lines | -26 |
| sshserver | 165 lines | 132 lines | -33 |
| headend | 190 lines | 153 lines | -37 |
| bench/tunnel.go | 90 lines | 64 lines | -26 |
| bench/bench.go | ~500 lines | ~460 lines | -40 |

### Key patterns extracted

1. **`httphandler.Runner`** — `RunCommands(cmds []string) (string, error)`. httpserver/http3server use a `deviceRunner` adapter; proxy implements it directly via SSH forwarding.

2. **`sshutil.SessionHandler`** — `func(ssh.Channel, <-chan *ssh.Request)`. sshserver passes its exec/shell handler; headend passes its HTTP-forwarding handler.

3. **`sshFreshBench()`** — the dial→execute→close→record pattern used by SSH fresh-conn, batch-exec, pty-fresh, and all 4 tunnel modes. Takes an `execFn func(*ssh.Client) error`.

### What this enables

Adding RESTCONF (#3) server-side is now:
```go
type restconfRunner struct{ dev *device.Device }
func (r restconfRunner) RunCommands(cmds []string) (string, error) { ... }
// Then: httphandler.Mux(user, pass, restconfRunner{dev})
```

## Testing

All existing tests pass with `-race`, 0 lint issues. New packages are exercised through existing integration tests (httpserver, http3server, proxy, sshserver, headend, bench all have tests that verify end-to-end behavior).