### PR TITLE
fix: P2 improvements — readiness, hostname, Summarize struct, cleanup

### DIFF
--- a/cmd/clibench/bench.go
+++ b/cmd/clibench/bench.go
@@ -42,10 +42,9 @@ type BenchCmd struct {
 
 	User        string `help:"Username." default:"admin" short:"u"`
 	Pass        string `help:"Password." default:"admin" short:"p"`
+	Hostname    string `help:"Device hostname." default:"bench-rtr"`
 	Transcripts string `help:"Transcript directory." default:"transcripts"`
 }
-
-const hostname = "bench-rtr"
 
 func (b *BenchCmd) has(t string) bool {
 	for _, v := range b.Transport {
@@ -212,7 +211,12 @@ func (b *BenchCmd) startServers(e *benchEnv, dev *device.Device) error {
 		return err
 	}
 
-	time.Sleep(500 * time.Millisecond)
+	// Wait for TCP servers to be ready
+	for _, addr := range []string{e.sshAddr, e.httpsAddr, e.backendSSHAddr, e.proxyAddr, e.headendHTTPSAddr} {
+		if err := waitReady(addr, 5*time.Second); err != nil {
+			return err
+		}
+	}
 	log.Printf("Servers ready — profile=%s, simulated RTT=%.0fms", b.Latency, e.rttMs)
 	return nil
 }
@@ -259,7 +263,7 @@ func (b *BenchCmd) runBenchmarks(e *benchEnv, pc *pktcount.Counter) []stats.Resu
 		Commands:    b.Commands,
 		Profile:     b.Latency,
 		RTTms:       e.rttMs,
-		Hostname:    hostname,
+		Hostname:    b.Hostname,
 	}
 
 	pktWrap := func(fn func() []stats.Result) []stats.Result {
@@ -326,7 +330,7 @@ func (b *BenchCmd) Run() error {
 		defer netem.Teardown()
 	}
 
-	dev, err := device.New(hostname, b.User, b.Pass, b.Transcripts)
+	dev, err := device.New(b.Hostname, b.User, b.Pass, b.Transcripts)
 	if err != nil {
 		return fmt.Errorf("device: %w", err)
 	}
@@ -340,6 +344,20 @@ func (b *BenchCmd) Run() error {
 
 	results := b.runBenchmarks(e, pc)
 	return outputResults(results, b.Output)
+}
+
+// waitReady polls a TCP address until it accepts connections or timeout.
+func waitReady(addr string, timeout time.Duration) error {
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		c, err := net.DialTimeout("tcp", addr, 100*time.Millisecond)
+		if err == nil {
+			c.Close()
+			return nil
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	return fmt.Errorf("server %s not ready after %v", addr, timeout)
 }
 
 func outputResults(results []stats.Result, format string) error {

--- a/cmd/clibench/server.go
+++ b/cmd/clibench/server.go
@@ -18,7 +18,7 @@ type ServerCmd struct {
 	SSHPort     int    `help:"SSH listen port." default:"2222"`
 	HTTPSPort   int    `help:"HTTPS listen port." default:"8443"`
 	HTTP3Port   int    `help:"HTTP/3 listen port." default:"8444"`
-	Hostname    string `help:"Device hostname." default:"benchmark-rtr"`
+	Hostname    string `help:"Device hostname." default:"bench-rtr"`
 	User        string `help:"Username." default:"admin" short:"u"`
 	Pass        string `help:"Password." default:"admin" short:"p"`
 	Transcripts string `help:"Transcript directory." default:"transcripts"`

--- a/cmd/clibench/smoketest.go
+++ b/cmd/clibench/smoketest.go
@@ -19,12 +19,13 @@ import (
 
 // SmoketestCmd runs a quick integration smoke test.
 type SmoketestCmd struct {
+	Hostname    string `help:"Device hostname." default:"bench-rtr"`
 	Transcripts string `help:"Transcript directory." default:"transcripts"`
 }
 
 // Run executes the smoke test.
 func (s *SmoketestCmd) Run() error {
-	dev, err := device.New("test-rtr", "admin", "admin", s.Transcripts)
+	dev, err := device.New(s.Hostname, "admin", "admin", s.Transcripts)
 	if err != nil {
 		return fmt.Errorf("device: %w", err)
 	}
@@ -60,7 +61,19 @@ func (s *SmoketestCmd) Run() error {
 	h3Srv.SetPacketConn(h3Conn)
 	go h3Srv.ListenAndServe()
 
-	time.Sleep(500 * time.Millisecond)
+	// Wait for servers
+	for _, addr := range []string{sshLn.Addr().String(), httpsLn.Addr().String()} {
+		deadline := time.Now().Add(5 * time.Second)
+		for time.Now().Before(deadline) {
+			c, err := net.DialTimeout("tcp", addr, 100*time.Millisecond)
+			if err == nil {
+				c.Close()
+				break
+			}
+			time.Sleep(10 * time.Millisecond)
+		}
+	}
+	time.Sleep(100 * time.Millisecond) // UDP/QUIC has no dial check
 
 	// Test HTTPS
 	fmt.Println("\n=== HTTPS Test ===")

--- a/internal/bench/bench.go
+++ b/internal/bench/bench.go
@@ -42,6 +42,21 @@ type Config struct {
 	Hostname    string // device hostname for PTY prompt detection
 }
 
+// summarize is a convenience wrapper around stats.Summarize using Config fields.
+func (c Config) summarize(transport, op string, times []time.Duration, counts counters) stats.Result {
+	return stats.Summarize(stats.SummarizeConfig{
+		Transport:   transport,
+		Operation:   op,
+		Commands:    c.Commands,
+		Iterations:  c.Iterations,
+		Concurrency: c.Concurrency,
+		Profile:     c.Profile,
+		RTTms:       c.RTTms,
+		Times:       times,
+		Counts:      counts.iter(),
+	})
+}
+
 func sshConfig(user, pass string) *ssh.ClientConfig {
 	return &ssh.ClientConfig{
 		User:            user,
@@ -206,12 +221,12 @@ func SSH(c Config) []stats.Result {
 	})
 
 	results := []stats.Result{
-		stats.Summarize("ssh", "fresh-conn", c.Commands, c.Iterations, c.Concurrency, c.Profile, c.RTTms, freshTimes, freshC.iter()),
+		c.summarize("ssh", "fresh-conn", freshTimes, freshC),
 	}
 	if reuseTimes != nil {
-		results = append(results, stats.Summarize("ssh", "reuse-conn", c.Commands, c.Iterations, c.Concurrency, c.Profile, c.RTTms, reuseTimes, reuseC.iter()))
+		results = append(results, c.summarize("ssh", "reuse-conn", reuseTimes, reuseC))
 	}
-	results = append(results, stats.Summarize("ssh", "batch-exec", c.Commands, c.Iterations, c.Concurrency, c.Profile, c.RTTms, batchTimes, batchC.iter()))
+	results = append(results, c.summarize("ssh", "batch-exec", batchTimes, batchC))
 
 	// Mode 4: PTY/shell — fresh connection per iteration
 	prompt := c.Hostname + "#"
@@ -223,7 +238,7 @@ func SSH(c Config) []stats.Result {
 		defer sess.Close()
 		return ptyExecCmds(sess, prompt, c.Commands)
 	})
-	results = append(results, stats.Summarize("ssh", "pty-fresh", c.Commands, c.Iterations, c.Concurrency, c.Profile, c.RTTms, ptyFreshTimes, ptyFreshC.iter()))
+	results = append(results, c.summarize("ssh", "pty-fresh", ptyFreshTimes, ptyFreshC))
 
 	// Mode 5: PTY/shell — reuse connection
 	ptyConn, ptyCC, err := sshDialCounted(c.Addr, cfg)
@@ -254,7 +269,7 @@ func SSH(c Config) []stats.Result {
 			return time.Since(start)
 		})
 		ptyConn.Close()
-		results = append(results, stats.Summarize("ssh", "pty-reuse", c.Commands, c.Iterations, c.Concurrency, c.Profile, c.RTTms, ptyReuseTimes, ptyReuseC.iter()))
+		results = append(results, c.summarize("ssh", "pty-reuse", ptyReuseTimes, ptyReuseC))
 	}
 
 	return results
@@ -389,9 +404,9 @@ func HTTPS(c Config) []stats.Result {
 	})
 
 	results := []stats.Result{
-		stats.Summarize("https", "fresh-conn", c.Commands, c.Iterations, c.Concurrency, c.Profile, c.RTTms, freshTimes, freshC.iter()),
-		stats.Summarize("https", "keep-alive", c.Commands, c.Iterations, c.Concurrency, c.Profile, c.RTTms, reuseTimes, keepC.iter()),
-		stats.Summarize("https", "batch-post", c.Commands, c.Iterations, c.Concurrency, c.Profile, c.RTTms, batchTimes, batchC.iter()),
+		c.summarize("https", "fresh-conn", freshTimes, freshC),
+		c.summarize("https", "keep-alive", reuseTimes, keepC),
+		c.summarize("https", "batch-post", batchTimes, batchC),
 	}
 
 	// Mode 4: multi-command GET (ASA slash syntax)
@@ -435,7 +450,7 @@ func HTTPS(c Config) []stats.Result {
 			}
 			return time.Since(start)
 		})
-		results = append(results, stats.Summarize("https", "multi-cmd", c.Commands, c.Iterations, c.Concurrency, c.Profile, c.RTTms, multiTimes, multiC.iter()))
+		results = append(results, c.summarize("https", "multi-cmd", multiTimes, multiC))
 	}
 
 	return results
@@ -513,8 +528,8 @@ func Proxy(c ProxyConfig) []stats.Result {
 	})
 
 	return []stats.Result{
-		stats.Summarize("proxy", "fresh-ssh", c.Commands, c.Iterations, c.Concurrency, c.Profile, c.RTTms, freshTimes, freshC.iter()),
-		stats.Summarize("proxy", "pooled-ssh", c.Commands, c.Iterations, c.Concurrency, c.Profile, c.RTTms, pooledTimes, pooledC.iter()),
+		c.summarize("proxy", "fresh-ssh", freshTimes, freshC),
+		c.summarize("proxy", "pooled-ssh", pooledTimes, pooledC),
 	}
 }
 

--- a/internal/bench/bench_test.go
+++ b/internal/bench/bench_test.go
@@ -14,6 +14,19 @@ import (
 	"github.com/lykinsbd/clibench/internal/stats"
 )
 
+func waitTCP(t *testing.T, addr string) {
+	t.Helper()
+	for i := 0; i < 100; i++ {
+		c, err := net.DialTimeout("tcp", addr, 50*time.Millisecond)
+		if err == nil {
+			c.Close()
+			return
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	t.Fatalf("server %s not ready", addr)
+}
+
 func setupServers(t *testing.T) (sshAddr, httpsAddr string) {
 	t.Helper()
 	dir := t.TempDir()
@@ -37,6 +50,7 @@ func setupServers(t *testing.T) (sshAddr, httpsAddr string) {
 	}
 	sshSrv.SetListener(sshLn)
 	go sshSrv.ListenAndServe()
+	t.Cleanup(func() { sshSrv.Close() })
 
 	httpsLn, err := net.Listen("tcp", "127.0.0.1:0")
 	if err != nil {
@@ -45,8 +59,10 @@ func setupServers(t *testing.T) (sshAddr, httpsAddr string) {
 	httpSrv := httpserver.New(httpsLn.Addr().String(), dev)
 	httpSrv.SetListener(httpsLn)
 	go httpSrv.ListenAndServeTLS()
+	t.Cleanup(func() { httpSrv.Close() })
 
-	time.Sleep(200 * time.Millisecond)
+	waitTCP(t, sshLn.Addr().String())
+	waitTCP(t, httpsLn.Addr().String())
 	return sshLn.Addr().String(), httpsLn.Addr().String()
 }
 
@@ -129,6 +145,7 @@ func TestProxy(t *testing.T) {
 	pFresh := proxy.New(freshLn.Addr().String(), sshAddr, "admin", "admin", false)
 	pFresh.SetListener(freshLn)
 	go pFresh.ListenAndServeTLS()
+	t.Cleanup(func() { pFresh.Close() })
 
 	pooledLn, err := net.Listen("tcp", "127.0.0.1:0")
 	if err != nil {
@@ -137,8 +154,10 @@ func TestProxy(t *testing.T) {
 	pPooled := proxy.New(pooledLn.Addr().String(), sshAddr, "admin", "admin", true)
 	pPooled.SetListener(pooledLn)
 	go pPooled.ListenAndServeTLS()
+	t.Cleanup(func() { pPooled.Close() })
 
-	time.Sleep(200 * time.Millisecond)
+	waitTCP(t, freshLn.Addr().String())
+	waitTCP(t, pooledLn.Addr().String())
 
 	results := Proxy(ProxyConfig{
 		Config:     baseCfg(""),

--- a/internal/bench/http3.go
+++ b/internal/bench/http3.go
@@ -128,9 +128,9 @@ func HTTP3(c Config) []stats.Result {
 	batchTr.Close()
 
 	results := []stats.Result{
-		stats.Summarize("http3", "fresh-conn", c.Commands, c.Iterations, c.Concurrency, c.Profile, c.RTTms, freshTimes, freshC.iter()),
-		stats.Summarize("http3", "keep-alive", c.Commands, c.Iterations, c.Concurrency, c.Profile, c.RTTms, keepTimes, keepC.iter()),
-		stats.Summarize("http3", "batch-post", c.Commands, c.Iterations, c.Concurrency, c.Profile, c.RTTms, batchTimes, batchC.iter()),
+		c.summarize("http3", "fresh-conn", freshTimes, freshC),
+		c.summarize("http3", "keep-alive", keepTimes, keepC),
+		c.summarize("http3", "batch-post", batchTimes, batchC),
 	}
 
 	// Mode 4: 0-RTT resumption
@@ -172,7 +172,7 @@ func HTTP3(c Config) []stats.Result {
 		tr.Close()
 		return time.Since(start)
 	})
-	results = append(results, stats.Summarize("http3", "0rtt-resumption", c.Commands, c.Iterations, c.Concurrency, c.Profile, c.RTTms, zeroTimes, zeroC.iter()))
+	results = append(results, c.summarize("http3", "0rtt-resumption", zeroTimes, zeroC))
 
 	return results
 }

--- a/internal/bench/http3_test.go
+++ b/internal/bench/http3_test.go
@@ -29,7 +29,8 @@ func setupHTTP3Server(t *testing.T) string {
 	srv := http3server.New(conn.LocalAddr().String(), dev)
 	srv.SetPacketConn(conn)
 	go srv.ListenAndServe()
-	time.Sleep(200 * time.Millisecond)
+	t.Cleanup(func() { srv.Close() })
+	time.Sleep(100 * time.Millisecond) // UDP: no dial-based readiness check
 	return conn.LocalAddr().String()
 }
 

--- a/internal/bench/tunnel.go
+++ b/internal/bench/tunnel.go
@@ -58,7 +58,7 @@ func tunnelModes(c TunnelConfig, cfg *ssh.ClientConfig, addr, op string) []stats
 	})
 
 	return []stats.Result{
-		stats.Summarize("tunnel", op, c.Commands, c.Iterations, c.Concurrency, c.Profile, c.RTTms, freshTimes, freshC.iter()),
-		stats.Summarize("tunnel", op+"-batch", c.Commands, c.Iterations, c.Concurrency, c.Profile, c.RTTms, batchTimes, batchC.iter()),
+		c.summarize("tunnel", op, freshTimes, freshC),
+		c.summarize("tunnel", op+"-batch", batchTimes, batchC),
 	}
 }

--- a/internal/bench/tunnel_test.go
+++ b/internal/bench/tunnel_test.go
@@ -3,7 +3,6 @@ package bench
 import (
 	"net"
 	"testing"
-	"time"
 
 	"github.com/lykinsbd/clibench/internal/headend"
 	"github.com/lykinsbd/clibench/internal/proxy"
@@ -21,6 +20,7 @@ func setupTunnel(t *testing.T) (httpsHeadendAddr, h3HeadendAddr string) {
 	p := proxy.New(siteLn.Addr().String(), sshAddr, "admin", "admin", true)
 	p.SetListener(siteLn)
 	go p.ListenAndServeTLS()
+	t.Cleanup(func() { p.Close() })
 
 	// Headend proxy (HTTPS WAN)
 	hHTTPSLn, err := net.Listen("tcp", "127.0.0.1:0")
@@ -33,6 +33,7 @@ func setupTunnel(t *testing.T) (httpsHeadendAddr, h3HeadendAddr string) {
 	}
 	hHTTPS.SetListener(hHTTPSLn)
 	go hHTTPS.ListenAndServe()
+	t.Cleanup(func() { hHTTPS.Close() })
 
 	// Headend proxy (HTTP/3 WAN) — still talks HTTPS to site proxy for now
 	hH3Ln, err := net.Listen("tcp", "127.0.0.1:0")
@@ -45,8 +46,11 @@ func setupTunnel(t *testing.T) (httpsHeadendAddr, h3HeadendAddr string) {
 	}
 	hH3.SetListener(hH3Ln)
 	go hH3.ListenAndServe()
+	t.Cleanup(func() { hH3.Close() })
 
-	time.Sleep(300 * time.Millisecond)
+	waitTCP(t, siteLn.Addr().String())
+	waitTCP(t, hHTTPSLn.Addr().String())
+	waitTCP(t, hH3Ln.Addr().String())
 	return hHTTPSLn.Addr().String(), hH3Ln.Addr().String()
 }
 

--- a/internal/stats/stats.go
+++ b/internal/stats/stats.go
@@ -43,13 +43,27 @@ type IterCounts struct {
 	Writes []int
 }
 
+// SummarizeConfig holds the parameters for Summarize.
+type SummarizeConfig struct {
+	Transport   string
+	Operation   string
+	Commands    int
+	Iterations  int
+	Concurrency int
+	Profile     string
+	RTTms       float64
+	Times       []time.Duration
+	Counts      IterCounts
+}
+
 // Summarize computes statistics from a slice of durations.
-// An optional IterCounts provides per-iteration round-trip and packet counts;
-// median values are stored in the result.
-func Summarize(transport, op string, cmds, iterations, concurrency int, profile string, rttMs float64, times []time.Duration, counts ...IterCounts) Result {
-	valid := make([]float64, 0, len(times))
+func Summarize(cfg SummarizeConfig) Result {
+	transport, op := cfg.Transport, cfg.Operation
+	iterations := cfg.Iterations
+
+	valid := make([]float64, 0, len(cfg.Times))
 	errors := 0
-	for _, t := range times {
+	for _, t := range cfg.Times {
 		if t == ErrDuration {
 			errors++
 			continue
@@ -61,9 +75,9 @@ func Summarize(transport, op string, cmds, iterations, concurrency int, profile 
 	}
 	if len(valid) == 0 {
 		return Result{
-			Transport: transport, Operation: op, Commands: cmds,
-			Iterations: iterations, Errors: errors, Concurrency: concurrency,
-			Latency: profile, RTTms: rttMs,
+			Transport: transport, Operation: op, Commands: cfg.Commands,
+			Iterations: iterations, Errors: errors, Concurrency: cfg.Concurrency,
+			Latency: cfg.Profile, RTTms: cfg.RTTms,
 		}
 	}
 
@@ -87,19 +101,19 @@ func Summarize(transport, op string, cmds, iterations, concurrency int, profile 
 	}
 
 	var ic IterCounts
-	if len(counts) > 0 {
-		ic = counts[0]
+	if len(cfg.Counts.Trips) > 0 || len(cfg.Counts.Reads) > 0 {
+		ic = cfg.Counts
 	}
 
 	return Result{
 		Transport:   transport,
 		Operation:   op,
-		Commands:    cmds,
+		Commands:    cfg.Commands,
 		Iterations:  iterations,
 		Errors:      errors,
-		Concurrency: concurrency,
-		Latency:     profile,
-		RTTms:       rttMs,
+		Concurrency: cfg.Concurrency,
+		Latency:     cfg.Profile,
+		RTTms:       cfg.RTTms,
 		RoundTrips:  medianInts(ic.Trips),
 		ReadOps:     medianInts(ic.Reads),
 		WriteOps:    medianInts(ic.Writes),

--- a/internal/stats/stats_test.go
+++ b/internal/stats/stats_test.go
@@ -54,7 +54,7 @@ func TestPercentileKnownValues(t *testing.T) {
 
 func TestSummarizeBasic(t *testing.T) {
 	times := []time.Duration{2 * time.Millisecond, 4 * time.Millisecond, 6 * time.Millisecond}
-	r := Summarize("t", "op", 1, 3, 1, "local", 0, times)
+	r := Summarize(SummarizeConfig{Transport: "t", Operation: "op", Commands: 1, Iterations: 3, Concurrency: 1, Profile: "local", RTTms: 0, Times: times})
 	if r.Errors != 0 {
 		t.Errorf("errors = %d", r.Errors)
 	}
@@ -77,7 +77,7 @@ func TestStddevKnownValues(t *testing.T) {
 	for i, v := range vals {
 		times[i] = time.Duration(v) * time.Millisecond
 	}
-	r := Summarize("t", "op", 1, 8, 1, "local", 0, times)
+	r := Summarize(SummarizeConfig{Transport: "t", Operation: "op", Commands: 1, Iterations: 8, Concurrency: 1, Profile: "local", RTTms: 0, Times: times})
 	want := math.Sqrt(32.0 / 7.0) // ≈ 2.1381
 	if math.Abs(r.StddevMs-want) > 0.01 {
 		t.Errorf("stddev = %v, want %v", r.StddevMs, want)
@@ -86,7 +86,7 @@ func TestStddevKnownValues(t *testing.T) {
 
 func TestSummarizeAllErrors(t *testing.T) {
 	times := []time.Duration{ErrDuration, ErrDuration, ErrDuration}
-	r := Summarize("t", "op", 1, 3, 1, "local", 0, times)
+	r := Summarize(SummarizeConfig{Transport: "t", Operation: "op", Commands: 1, Iterations: 3, Concurrency: 1, Profile: "local", RTTms: 0, Times: times})
 	if r.Errors != 3 {
 		t.Errorf("errors = %d, want 3", r.Errors)
 	}
@@ -97,7 +97,7 @@ func TestSummarizeAllErrors(t *testing.T) {
 
 func TestSummarizePartialErrors(t *testing.T) {
 	times := []time.Duration{ErrDuration, 2 * time.Millisecond, 4 * time.Millisecond}
-	r := Summarize("t", "op", 1, 3, 1, "local", 0, times)
+	r := Summarize(SummarizeConfig{Transport: "t", Operation: "op", Commands: 1, Iterations: 3, Concurrency: 1, Profile: "local", RTTms: 0, Times: times})
 	if r.Errors != 1 {
 		t.Errorf("errors = %d, want 1", r.Errors)
 	}
@@ -108,7 +108,7 @@ func TestSummarizePartialErrors(t *testing.T) {
 
 func TestErrDurationSentinel(t *testing.T) {
 	times := []time.Duration{ErrDuration, 5 * time.Millisecond, ErrDuration, 10 * time.Millisecond}
-	r := Summarize("t", "op", 1, 4, 1, "local", 0, times)
+	r := Summarize(SummarizeConfig{Transport: "t", Operation: "op", Commands: 1, Iterations: 4, Concurrency: 1, Profile: "local", RTTms: 0, Times: times})
 	if r.Errors != 2 {
 		t.Errorf("errors = %d, want 2", r.Errors)
 	}
@@ -171,7 +171,7 @@ func TestSummarizeWithTrips(t *testing.T) {
 		Reads:  []int{10, 12, 10},
 		Writes: []int{8, 9, 8},
 	}
-	r := Summarize("ssh", "fresh-conn", 1, 3, 1, "local", 0, times, ic)
+	r := Summarize(SummarizeConfig{Transport: "ssh", Operation: "fresh-conn", Commands: 1, Iterations: 3, Concurrency: 1, Profile: "local", RTTms: 0, Times: times, Counts: ic})
 	if r.RoundTrips != 5 { // median of [5, 5, 7] = 5
 		t.Errorf("RoundTrips = %d, want 5", r.RoundTrips)
 	}
@@ -185,7 +185,7 @@ func TestSummarizeWithTrips(t *testing.T) {
 
 func TestSummarizeWithoutTrips(t *testing.T) {
 	times := []time.Duration{10 * time.Millisecond}
-	r := Summarize("https", "keep-alive", 1, 1, 1, "local", 0, times)
+	r := Summarize(SummarizeConfig{Transport: "https", Operation: "keep-alive", Commands: 1, Iterations: 1, Concurrency: 1, Profile: "local", RTTms: 0, Times: times})
 	if r.RoundTrips != 0 {
 		t.Errorf("RoundTrips = %d, want 0 when no counts provided", r.RoundTrips)
 	}


### PR DESCRIPTION
P2 improvements from the architecture review (#20).

## Changes

### 1. Dial-based server readiness (replaces time.Sleep)

All `time.Sleep(200-500ms)` calls for server startup replaced with `waitReady()`/`waitTCP()` that polls until the port accepts connections. Tests are ~1.5s faster. UDP/QUIC servers still use a short sleep since there's no TCP dial check for UDP.

### 2. Hostname consistency

All three commands now default to `"bench-rtr"`:
- `BenchCmd` — was `const hostname = "bench-rtr"`, now `--hostname` flag
- `ServerCmd` — was `"benchmark-rtr"`, now `"bench-rtr"`
- `SmoketestCmd` — was hardcoded `"test-rtr"`, now `--hostname` flag

PTY prompt detection depends on hostname matching, so this prevents subtle test failures.

### 3. `stats.Summarize` config struct

Before (8 positional params — easy to get wrong):
```go
stats.Summarize("ssh", "fresh-conn", c.Commands, c.Iterations, c.Concurrency, c.Profile, c.RTTms, times, counts.iter())
```

After:
```go
c.summarize("ssh", "fresh-conn", times, counts)
```

The `Config.summarize()` helper builds `stats.SummarizeConfig` from the bench config fields. All 17 call sites updated.

### 4. `t.Cleanup(srv.Close)` on all test servers

Prevents goroutine leaks during test runs. Applied to bench_test.go, http3_test.go, tunnel_test.go.

## Testing

All tests pass with `-race`, 0 lint issues. Bench tests ~1.5s faster.