### PR TITLE
fix: P3 nits — CSV order, medianInts, port docs, headend Close

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -91,9 +91,11 @@ defaults, short flags, and help text are all struct tags.
 ## Adding a Benchmark Mode
 
 1. Add mode logic in the appropriate function in `internal/bench/`.
-2. Use `stats.RunParallel` for iteration execution and `stats.Summarize` for results.
-3. Add a test in the corresponding `_test.go` file.
-4. Update the README benchmark modes table.
+2. Use `stats.RunParallel` for iteration execution and `Config.summarize()` for results.
+3. For HTTP-based servers, implement `httphandler.Runner` and use `httphandler.Mux()`.
+4. For SSH-based servers, use `sshutil.ServerConfig()` and `sshutil.Serve()`.
+5. Add a test in the corresponding `_test.go` file.
+6. Update the README benchmark modes table.
 
 ## Adding a Command Transcript
 

--- a/README.md
+++ b/README.md
@@ -199,13 +199,17 @@ cmd/
 internal/
   bench/      # Benchmark orchestration (modes, iteration logic)
   device/     # Command engine, prefix matching, transcript loading
-  sshserver/  # crypto/ssh server
-  httpserver/ # net/http + TLS server (ASA-style API)
-  http3server/ # HTTP/3 (QUIC) server (same ASA-style API over QUIC)
   headend/    # SSH→HTTP headend proxy (tunnel automation side)
+  http3server/ # HTTP/3 (QUIC) server (same ASA-style API over QUIC)
+  httphandler/ # Shared HTTP handler logic (Runner interface, auth, routes)
+  httpserver/ # net/http + TLS server (ASA-style API)
   latency/    # Userspace delay injection (fallback, --userspace flag)
   netem/      # tc netem setup via netlink (default, requires root)
+  pktcount/   # AF_PACKET real packet counter (Linux, requires root)
   proxy/      # HTTPS→SSH site proxy (fresh + pooled modes)
+  rtcount/    # Connection wrappers counting round trips + I/O ops
+  sshserver/  # crypto/ssh server
+  sshutil/    # Shared SSH server scaffolding (keygen, accept loop)
   stats/      # Benchmark statistics (percentile, summarize, runParallel)
   tlsutil/    # Shared self-signed TLS config generator
 scripts/      # Result generation and helper scripts
@@ -231,6 +235,7 @@ sudo go test -race -v -tags netem_root ./internal/netem/
 |---|---|---|
 | (none) | Nothing | All unit tests, integration tests, proxy tests |
 | `netem_root` | Root / `CAP_NET_ADMIN` | Tests that call `netem.Setup()` and verify kernel qdisc state |
+| `pktcount_root` | Root / `CAP_NET_RAW` | Tests that open AF_PACKET sockets for real packet counting |
 
 ### Test Coverage
 

--- a/cmd/clibench/bench.go
+++ b/cmd/clibench/bench.go
@@ -56,6 +56,17 @@ func (b *BenchCmd) has(t string) bool {
 }
 
 // benchEnv holds all addresses computed from BenchCmd ports.
+// Port layout (from base ports):
+//   SSHPort          — main SSH server (WAN delay)
+//   SSHPort+1000     — backend SSH for proxy/tunnel (campus delay)
+//   HTTPSPort        — main HTTPS server (WAN delay)
+//   HTTP3Port        — main HTTP/3 server (WAN delay)
+//   ProxyPort        — proxy fresh-SSH mode (WAN delay)
+//   ProxyPort+1      — proxy pooled-SSH mode (WAN delay)
+//   ProxyPort+2      — tunnel site HTTPS proxy (WAN delay)
+//   ProxyPort+3      — tunnel site HTTP/3 proxy (WAN delay)
+//   HeadendHTTPSPort — tunnel headend SSH (campus delay)
+//   HeadendH3Port    — tunnel headend SSH/H3 (campus delay)
 type benchEnv struct {
 	sshAddr             string
 	httpsAddr           string

--- a/cmd/clibench/format.go
+++ b/cmd/clibench/format.go
@@ -11,7 +11,7 @@ import (
 
 func writeTable(w io.Writer, results []stats.Result) error {
 	tw := tabwriter.NewWriter(w, 0, 4, 2, ' ', 0)
-	fmt.Fprintln(tw, "TRANSPORT\tOPERATION\tCMDS\tITER\tERR\tRT\tRD_OPS\tWR_OPS\tPKT_IN\tPKT_OUT\tAVG(ms)\tMIN(ms)\tP50(ms)\tP95(ms)\tMAX(ms)\tSTDDEV")
+	fmt.Fprintln(tw, "TRANSPORT\tOPERATION\tCMDS\tITER\tERR\tRT\tRD_OPS\tWR_OPS\tPKT_IN\tPKT_OUT\tAVG(ms)\tMIN(ms)\tP50(ms)\tP95(ms)\tMAX(ms)\tSTDDEV(ms)")
 	for _, r := range results {
 		fmt.Fprintf(tw, "%s\t%s\t%d\t%d\t%d\t%d\t%d\t%d\t%d\t%d\t%.2f\t%.2f\t%.2f\t%.2f\t%.2f\t%.2f\n",
 			r.Transport, r.Operation, r.Commands, r.Iterations, r.Errors,
@@ -23,11 +23,12 @@ func writeTable(w io.Writer, results []stats.Result) error {
 
 func writeCSV(w io.Writer, results []stats.Result) error {
 	cw := csv.NewWriter(w)
+	// Column order matches table: avg, min, p50, p95, max, stddev
 	_ = cw.Write([]string{
 		"transport", "operation", "commands", "iterations", "errors",
 		"concurrency", "latency_profile", "simulated_rtt_ms",
 		"round_trips", "read_ops", "write_ops", "packets_in", "packets_out",
-		"avg_ms", "min_ms", "max_ms", "p50_ms", "p95_ms", "stddev_ms",
+		"avg_ms", "min_ms", "p50_ms", "p95_ms", "max_ms", "stddev_ms",
 	})
 	for _, r := range results {
 		_ = cw.Write([]string{
@@ -39,8 +40,8 @@ func writeCSV(w io.Writer, results []stats.Result) error {
 			fmt.Sprintf("%d", r.ReadOps), fmt.Sprintf("%d", r.WriteOps),
 			fmt.Sprintf("%d", r.PacketsIn), fmt.Sprintf("%d", r.PacketsOut),
 			fmt.Sprintf("%.3f", r.AvgMs), fmt.Sprintf("%.3f", r.MinMs),
-			fmt.Sprintf("%.3f", r.MaxMs), fmt.Sprintf("%.3f", r.P50Ms),
-			fmt.Sprintf("%.3f", r.P95Ms), fmt.Sprintf("%.3f", r.StddevMs),
+			fmt.Sprintf("%.3f", r.P50Ms), fmt.Sprintf("%.3f", r.P95Ms),
+			fmt.Sprintf("%.3f", r.MaxMs), fmt.Sprintf("%.3f", r.StddevMs),
 		})
 	}
 	cw.Flush()

--- a/internal/headend/headend.go
+++ b/internal/headend/headend.go
@@ -71,7 +71,11 @@ func (s *Server) Addr() string {
 }
 
 // Close stops the server.
+// Close stops the server and releases the HTTP client.
 func (s *Server) Close() error {
+	if s.client != nil {
+		s.client.CloseIdleConnections()
+	}
 	if s.listener != nil {
 		return s.listener.Close()
 	}

--- a/internal/stats/stats.go
+++ b/internal/stats/stats.go
@@ -134,7 +134,11 @@ func medianInts(s []int) int {
 	c := make([]int, len(s))
 	copy(c, s)
 	sort.Ints(c)
-	return c[len(c)/2]
+	n := len(c)
+	if n%2 == 1 {
+		return c[n/2]
+	}
+	return (c[n/2-1] + c[n/2]) / 2
 }
 
 // Percentile returns the p-th percentile from a sorted slice.


### PR DESCRIPTION
Final cleanup items from the architecture review (#20).

## Changes

1. **CSV column order** — was `avg, min, max, p50, p95, stddev`; now matches table: `avg, min, p50, p95, max, stddev`. Also added `(ms)` to STDDEV table header.

2. **`medianInts` correctness** — was always returning upper-middle element for even-length slices (`[5, 7]` → 7). Now averages the two middle values (`[5, 7]` → 6), matching the standard definition.

3. **Port arithmetic documented** — `benchEnv` now has a comment explaining the full port layout (which port offsets are used and why).

4. **Headend `Close()`** — now calls `client.CloseIdleConnections()` to release HTTP transport resources on shutdown.

## Not addressed (diminishing returns)

- `Benchmark*` functions for instrumentation overhead — nice-to-have but not blocking anything

## Testing

All tests pass with `-race`, 0 lint issues.

Closes #20 (all P0/P1/P2/P3 items addressed).