### PR TITLE
fix: remaining P2 — testutil, shutdown normalization, CI privileged

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,6 +34,16 @@ jobs:
       - name: Test
         run: go test -race -count=1 -timeout 120s ./...
 
+  test-privileged:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+      - name: Test (netem + pktcount, requires root)
+        run: sudo go test -race -count=1 -timeout 60s -tags netem_root,pktcount_root ./internal/netem/ ./internal/pktcount/
+
   build:
     runs-on: ubuntu-latest
     steps:

--- a/internal/bench/bench_test.go
+++ b/internal/bench/bench_test.go
@@ -2,43 +2,18 @@ package bench
 
 import (
 	"net"
-	"os"
-	"path/filepath"
 	"testing"
-	"time"
 
-	"github.com/lykinsbd/clibench/internal/device"
 	"github.com/lykinsbd/clibench/internal/httpserver"
 	"github.com/lykinsbd/clibench/internal/proxy"
 	"github.com/lykinsbd/clibench/internal/sshserver"
 	"github.com/lykinsbd/clibench/internal/stats"
+	"github.com/lykinsbd/clibench/internal/testutil"
 )
-
-func waitTCP(t *testing.T, addr string) {
-	t.Helper()
-	for i := 0; i < 100; i++ {
-		c, err := net.DialTimeout("tcp", addr, 50*time.Millisecond)
-		if err == nil {
-			c.Close()
-			return
-		}
-		time.Sleep(10 * time.Millisecond)
-	}
-	t.Fatalf("server %s not ready", addr)
-}
 
 func setupServers(t *testing.T) (sshAddr, httpsAddr string) {
 	t.Helper()
-	dir := t.TempDir()
-	os.WriteFile(filepath.Join(dir, "show_version.txt"), []byte("TestOS v1\n"), 0644)
-	os.WriteFile(filepath.Join(dir, "show_ip_interface_brief.txt"), []byte("Gi0/0 10.0.0.1\n"), 0644)
-	os.WriteFile(filepath.Join(dir, "terminal_length_0.txt"), []byte(""), 0644)
-	os.WriteFile(filepath.Join(dir, "terminal_width_511.txt"), []byte(""), 0644)
-
-	dev, err := device.New("test-rtr", "admin", "admin", dir)
-	if err != nil {
-		t.Fatal(err)
-	}
+	dev := testutil.NewDevice(t)
 
 	sshLn, err := net.Listen("tcp", "127.0.0.1:0")
 	if err != nil {
@@ -61,8 +36,8 @@ func setupServers(t *testing.T) (sshAddr, httpsAddr string) {
 	go httpSrv.ListenAndServeTLS()
 	t.Cleanup(func() { httpSrv.Close() })
 
-	waitTCP(t, sshLn.Addr().String())
-	waitTCP(t, httpsLn.Addr().String())
+	testutil.WaitTCP(t, sshLn.Addr().String())
+	testutil.WaitTCP(t, httpsLn.Addr().String())
 	return sshLn.Addr().String(), httpsLn.Addr().String()
 }
 
@@ -156,8 +131,8 @@ func TestProxy(t *testing.T) {
 	go pPooled.ListenAndServeTLS()
 	t.Cleanup(func() { pPooled.Close() })
 
-	waitTCP(t, freshLn.Addr().String())
-	waitTCP(t, pooledLn.Addr().String())
+	testutil.WaitTCP(t, freshLn.Addr().String())
+	testutil.WaitTCP(t, pooledLn.Addr().String())
 
 	results := Proxy(ProxyConfig{
 		Config:     baseCfg(""),

--- a/internal/bench/http3_test.go
+++ b/internal/bench/http3_test.go
@@ -2,26 +2,16 @@ package bench
 
 import (
 	"net"
-	"os"
-	"path/filepath"
 	"testing"
 	"time"
 
-	"github.com/lykinsbd/clibench/internal/device"
 	"github.com/lykinsbd/clibench/internal/http3server"
+	"github.com/lykinsbd/clibench/internal/testutil"
 )
 
 func setupHTTP3Server(t *testing.T) string {
 	t.Helper()
-	dir := t.TempDir()
-	os.WriteFile(filepath.Join(dir, "show_version.txt"), []byte("TestOS v1\n"), 0644)
-	os.WriteFile(filepath.Join(dir, "show_ip_interface_brief.txt"), []byte("Gi0/0 10.0.0.1\n"), 0644)
-	os.WriteFile(filepath.Join(dir, "terminal_length_0.txt"), []byte(""), 0644)
-	os.WriteFile(filepath.Join(dir, "terminal_width_511.txt"), []byte(""), 0644)
-	dev, err := device.New("test-rtr", "admin", "admin", dir)
-	if err != nil {
-		t.Fatal(err)
-	}
+	dev := testutil.NewDevice(t)
 	conn, err := net.ListenPacket("udp", "127.0.0.1:0")
 	if err != nil {
 		t.Fatal(err)

--- a/internal/bench/tunnel_test.go
+++ b/internal/bench/tunnel_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/lykinsbd/clibench/internal/headend"
 	"github.com/lykinsbd/clibench/internal/proxy"
+	"github.com/lykinsbd/clibench/internal/testutil"
 )
 
 func setupTunnel(t *testing.T) (httpsHeadendAddr, h3HeadendAddr string) {
@@ -48,9 +49,9 @@ func setupTunnel(t *testing.T) (httpsHeadendAddr, h3HeadendAddr string) {
 	go hH3.ListenAndServe()
 	t.Cleanup(func() { hH3.Close() })
 
-	waitTCP(t, siteLn.Addr().String())
-	waitTCP(t, hHTTPSLn.Addr().String())
-	waitTCP(t, hH3Ln.Addr().String())
+	testutil.WaitTCP(t, siteLn.Addr().String())
+	testutil.WaitTCP(t, hHTTPSLn.Addr().String())
+	testutil.WaitTCP(t, hH3Ln.Addr().String())
 	return hHTTPSLn.Addr().String(), hH3Ln.Addr().String()
 }
 

--- a/internal/http3server/server.go
+++ b/internal/http3server/server.go
@@ -80,5 +80,9 @@ func (s *Server) ListenAndServe() error {
 		}
 	}
 	log.Printf("HTTP/3 listening on %s", s.conn.LocalAddr())
-	return s.srv.Serve(s.conn)
+	err = s.srv.Serve(s.conn)
+	if err != nil && err.Error() == "server closed" {
+		return nil
+	}
+	return err
 }

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -177,7 +177,11 @@ func (s *Server) ListenAndServeH3() error {
 		}
 	}
 	log.Printf("Proxy HTTP/3 listening on %s → SSH backend %s (pooled=%v)", s.packetConn.LocalAddr(), s.backendAddr, s.pooled)
-	return s.h3srv.Serve(s.packetConn)
+	err = s.h3srv.Serve(s.packetConn)
+	if err != nil && err.Error() == "server closed" {
+		return nil
+	}
+	return err
 }
 
 func (s *Server) getSSH() (*ssh.Client, bool, error) {

--- a/internal/testutil/testutil.go
+++ b/internal/testutil/testutil.go
@@ -1,0 +1,47 @@
+// Package testutil provides shared test helpers for creating devices
+// and waiting for server readiness.
+package testutil
+
+import (
+	"net"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/lykinsbd/clibench/internal/device"
+)
+
+// NewDevice creates a test device with standard transcripts in a temp dir.
+func NewDevice(t *testing.T) *device.Device {
+	t.Helper()
+	dir := t.TempDir()
+	write := func(name, content string) {
+		if err := os.WriteFile(filepath.Join(dir, name), []byte(content), 0644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	write("show_version.txt", "TestOS v1\n")
+	write("show_ip_interface_brief.txt", "Gi0/0 10.0.0.1\n")
+	write("terminal_length_0.txt", "")
+	write("terminal_width_511.txt", "")
+	dev, err := device.New("test-rtr", "admin", "admin", dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return dev
+}
+
+// WaitTCP polls addr until it accepts a connection or the test times out.
+func WaitTCP(t *testing.T, addr string) {
+	t.Helper()
+	for i := 0; i < 100; i++ {
+		c, err := net.DialTimeout("tcp", addr, 50*time.Millisecond)
+		if err == nil {
+			c.Close()
+			return
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	t.Fatalf("server %s not ready", addr)
+}


### PR DESCRIPTION
Final P2 items from #20.

## Changes

1. **`internal/testutil`** — new package with `NewDevice(t)` and `WaitTCP(t, addr)`, consolidating duplicated test helpers from 8+ test files. Bench tests refactored to use it.

2. **Shutdown normalization** — `http3server.ListenAndServe()` and `proxy.ListenAndServeH3()` now return nil on "server closed", matching the `httpserver` pattern with `http.ErrServerClosed`.

3. **CI privileged tests** — new `test-privileged` job runs `netem_root` and `pktcount_root` tagged tests with `sudo` on ubuntu-latest.

## Testing

All tests pass with `-race`, 0 lint issues.