### PR TITLE
fix: per-mode packet counts instead of transport-total (#24)

### DIFF
--- a/cmd/clibench/bench.go
+++ b/cmd/clibench/bench.go
@@ -276,19 +276,8 @@ func (b *BenchCmd) runBenchmarks(e *benchEnv, pc *pktcount.Counter) []stats.Resu
 		RTTms:       e.rttMs,
 		Hostname:    b.Hostname,
 	}
-
-	pktWrap := func(fn func() []stats.Result) []stats.Result {
-		if pc == nil {
-			return fn()
-		}
-		pc.Reset()
-		rs := fn()
-		totalIn, totalOut := pc.Snapshot()
-		if len(rs) > 0 {
-			rs[0].PacketsIn = totalIn
-			rs[0].PacketsOut = totalOut
-		}
-		return rs
+	if pc != nil {
+		cfg.PktCounter = pc
 	}
 
 	var results []stats.Result
@@ -296,32 +285,26 @@ func (b *BenchCmd) runBenchmarks(e *benchEnv, pc *pktcount.Counter) []stats.Resu
 	if b.has("ssh") {
 		c := cfg
 		c.Addr = e.sshAddr
-		results = append(results, pktWrap(func() []stats.Result { return bench.SSH(c) })...)
+		results = append(results, bench.SSH(c)...)
 	}
 	if b.has("https") {
 		c := cfg
 		c.Addr = e.httpsAddr
-		results = append(results, pktWrap(func() []stats.Result { return bench.HTTPS(c) })...)
+		results = append(results, bench.HTTPS(c)...)
 	}
 	if b.has("proxy") {
-		results = append(results, pktWrap(func() []stats.Result {
-			return bench.Proxy(bench.ProxyConfig{Config: cfg, FreshAddr: e.proxyAddr, PooledAddr: e.proxyPooledAddr})
-		})...)
+		results = append(results, bench.Proxy(bench.ProxyConfig{Config: cfg, FreshAddr: e.proxyAddr, PooledAddr: e.proxyPooledAddr})...)
 	}
 	if b.has("http3") {
 		c := cfg
 		c.Addr = e.http3Addr
-		results = append(results, pktWrap(func() []stats.Result { return bench.HTTP3(c) })...)
+		results = append(results, bench.HTTP3(c)...)
 	}
 	if b.has("tunnel-https") {
-		results = append(results, pktWrap(func() []stats.Result {
-			return bench.Tunnel(bench.TunnelConfig{Config: cfg, HTTPSHeadendAddr: e.headendHTTPSAddr})
-		})...)
+		results = append(results, bench.Tunnel(bench.TunnelConfig{Config: cfg, HTTPSHeadendAddr: e.headendHTTPSAddr})...)
 	}
 	if b.has("tunnel-http3") {
-		results = append(results, pktWrap(func() []stats.Result {
-			return bench.Tunnel(bench.TunnelConfig{Config: cfg, H3HeadendAddr: e.headendH3Addr})
-		})...)
+		results = append(results, bench.Tunnel(bench.TunnelConfig{Config: cfg, H3HeadendAddr: e.headendH3Addr})...)
 	}
 
 	return results

--- a/internal/bench/bench.go
+++ b/internal/bench/bench.go
@@ -29,22 +29,36 @@ var LatencyProfiles = map[string]time.Duration{
 	"transpacific":     87 * time.Millisecond,
 }
 
-// Config holds parameters for a benchmark run.
-type Config struct {
-	Addr        string // target server address (host:port)
-	User        string // authentication username
-	Pass        string // authentication password
-	Iterations  int    // number of iterations per benchmark mode
-	Concurrency int    // concurrent workers
-	Commands    int    // commands per iteration
-	Profile     string // latency profile name for result labeling
-	RTTms       float64 // simulated round-trip time in milliseconds
-	Hostname    string // device hostname for PTY prompt detection
+// PktCounter is the interface for packet counting (satisfied by *pktcount.Counter).
+type PktCounter interface {
+	Reset()
+	Snapshot() (in, out int)
 }
 
-// summarize is a convenience wrapper around stats.Summarize using Config fields.
+// Config holds parameters for a benchmark run.
+type Config struct {
+	Addr        string     // target server address (host:port)
+	User        string     // authentication username
+	Pass        string     // authentication password
+	Iterations  int        // number of iterations per benchmark mode
+	Concurrency int        // concurrent workers
+	Commands    int        // commands per iteration
+	Profile     string     // latency profile name for result labeling
+	RTTms       float64    // simulated round-trip time in milliseconds
+	Hostname    string     // device hostname for PTY prompt detection
+	PktCounter  PktCounter // optional packet counter (nil when unavailable)
+}
+
+// pktReset resets the packet counter (no-op if nil).
+func (c Config) pktReset() {
+	if c.PktCounter != nil {
+		c.PktCounter.Reset()
+	}
+}
+
+// summarize computes stats and snapshots packet counts accumulated since last pktReset.
 func (c Config) summarize(transport, op string, times []time.Duration, counts counters) stats.Result {
-	return stats.Summarize(stats.SummarizeConfig{
+	r := stats.Summarize(stats.SummarizeConfig{
 		Transport:   transport,
 		Operation:   op,
 		Commands:    c.Commands,
@@ -55,6 +69,10 @@ func (c Config) summarize(transport, op string, times []time.Duration, counts co
 		Times:       times,
 		Counts:      counts.iter(),
 	})
+	if c.PktCounter != nil {
+		r.PacketsIn, r.PacketsOut = c.PktCounter.Snapshot()
+	}
+	return r
 }
 
 func sshConfig(user, pass string) *ssh.ClientConfig {
@@ -152,6 +170,7 @@ func SSH(c Config) []stats.Result {
 	log.Printf("Benchmarking SSH (%d iterations, %d concurrency, %d cmds/iter)", c.Iterations, c.Concurrency, c.Commands)
 	cfg := sshConfig(c.User, c.Pass)
 
+	c.pktReset()
 	// Mode 1: fresh connection per iteration
 	freshTimes, freshC := sshFreshBench(c, c.Addr, cfg, func(conn *ssh.Client) error {
 		for i := 0; i < c.Commands; i++ {
@@ -168,6 +187,7 @@ func SSH(c Config) []stats.Result {
 		return nil
 	})
 
+	c.pktReset()
 	// Mode 2: reuse one connection (ControlMaster-style)
 	sharedConn, sharedCC, err := sshDialCounted(c.Addr, cfg)
 	var reuseTimes []time.Duration
@@ -208,6 +228,7 @@ func SSH(c Config) []stats.Result {
 		sharedConn.Close()
 	}
 
+	c.pktReset()
 	// Mode 3: batch exec
 	batchPayload := stats.GenerateExecPayload(c.Commands)
 	batchTimes, batchC := sshFreshBench(c, c.Addr, cfg, func(conn *ssh.Client) error {
@@ -228,6 +249,7 @@ func SSH(c Config) []stats.Result {
 	}
 	results = append(results, c.summarize("ssh", "batch-exec", batchTimes, batchC))
 
+	c.pktReset()
 	// Mode 4: PTY/shell — fresh connection per iteration
 	prompt := c.Hostname + "#"
 	ptyFreshTimes, ptyFreshC := sshFreshBench(c, c.Addr, cfg, func(conn *ssh.Client) error {
@@ -240,6 +262,7 @@ func SSH(c Config) []stats.Result {
 	})
 	results = append(results, c.summarize("ssh", "pty-fresh", ptyFreshTimes, ptyFreshC))
 
+	c.pktReset()
 	// Mode 5: PTY/shell — reuse connection
 	ptyConn, ptyCC, err := sshDialCounted(c.Addr, cfg)
 	if err == nil {
@@ -309,6 +332,7 @@ func HTTPS(c Config) []stats.Result {
 		return ct
 	}
 
+	c.pktReset()
 	// Mode 1: fresh connection per iteration
 	freshC := newCounters(c.Iterations)
 	freshTimes := stats.RunParallel(c.Iterations, c.Concurrency, func(idx int) time.Duration {
@@ -343,6 +367,7 @@ func HTTPS(c Config) []stats.Result {
 		return time.Since(start)
 	})
 
+	c.pktReset()
 	// Mode 2: keep-alive — shared connection, count per iteration
 	keepTr := countingTransport()
 	keepClient := &http.Client{Transport: keepTr.Transport, Timeout: 30 * time.Second}
@@ -367,6 +392,7 @@ func HTTPS(c Config) []stats.Result {
 		return time.Since(start)
 	})
 
+	c.pktReset()
 	// Mode 3: batch POST
 	batchPayload := stats.GenerateExecPayload(c.Commands)
 	batchTr := countingTransport()
@@ -409,6 +435,7 @@ func HTTPS(c Config) []stats.Result {
 		c.summarize("https", "batch-post", batchTimes, batchC),
 	}
 
+	c.pktReset()
 	// Mode 4: multi-command GET (ASA slash syntax)
 	if c.Commands > 1 {
 		cmdParts := make([]string, c.Commands)
@@ -514,12 +541,16 @@ func Proxy(c ProxyConfig) []stats.Result {
 		return time.Since(start), trips, reads, writes
 	}
 
+	c.pktReset()
 	freshC := newCounters(c.Iterations)
 	freshTimes := stats.RunParallel(c.Iterations, c.Concurrency, func(idx int) time.Duration {
 		d, t, r, w := doProxy(c.FreshAddr)
 		freshC.trips[idx], freshC.reads[idx], freshC.writes[idx] = t, r, w
 		return d
 	})
+	freshResult := c.summarize("proxy", "fresh-ssh", freshTimes, freshC)
+
+	c.pktReset()
 	pooledC := newCounters(c.Iterations)
 	pooledTimes := stats.RunParallel(c.Iterations, c.Concurrency, func(idx int) time.Duration {
 		d, t, r, w := doProxy(c.PooledAddr)
@@ -528,7 +559,7 @@ func Proxy(c ProxyConfig) []stats.Result {
 	})
 
 	return []stats.Result{
-		c.summarize("proxy", "fresh-ssh", freshTimes, freshC),
+		freshResult,
 		c.summarize("proxy", "pooled-ssh", pooledTimes, pooledC),
 	}
 }

--- a/internal/bench/http3.go
+++ b/internal/bench/http3.go
@@ -42,6 +42,7 @@ func HTTP3(c Config) []stats.Result {
 
 	tlsCfg := &tls.Config{InsecureSkipVerify: true, NextProtos: []string{http3.NextProtoH3}}
 
+	c.pktReset()
 	// Mode 1: fresh connection per iteration
 	freshC := newCounters(c.Iterations)
 	freshTimes := stats.RunParallel(c.Iterations, c.Concurrency, func(idx int) time.Duration {
@@ -63,6 +64,7 @@ func HTTP3(c Config) []stats.Result {
 		return time.Since(start)
 	})
 
+	c.pktReset()
 	// Mode 2: keep-alive (shared QUIC connection)
 	var keepCC *rtcount.PacketConn
 	keepTr := &http3.Transport{TLSClientConfig: tlsCfg.Clone(), Dial: h3Dial(&keepCC)}
@@ -89,6 +91,7 @@ func HTTP3(c Config) []stats.Result {
 	})
 	keepTr.Close()
 
+	c.pktReset()
 	// Mode 3: batch POST over shared connection
 	batchPayload := stats.GenerateExecPayload(c.Commands)
 	var batchCC *rtcount.PacketConn
@@ -133,6 +136,7 @@ func HTTP3(c Config) []stats.Result {
 		c.summarize("http3", "batch-post", batchTimes, batchC),
 	}
 
+	c.pktReset()
 	// Mode 4: 0-RTT resumption
 	sessionCache := tls.NewLRUClientSessionCache(1)
 	zeroRTTCfg := &tls.Config{

--- a/internal/bench/tunnel.go
+++ b/internal/bench/tunnel.go
@@ -32,6 +32,7 @@ func Tunnel(c TunnelConfig) []stats.Result {
 func tunnelModes(c TunnelConfig, cfg *ssh.ClientConfig, addr, op string) []stats.Result {
 	batchPayload := stats.GenerateExecPayload(c.Commands)
 
+	c.pktReset()
 	freshTimes, freshC := sshFreshBench(c.Config, addr, cfg, func(conn *ssh.Client) error {
 		for i := 0; i < c.Commands; i++ {
 			sess, err := conn.NewSession()
@@ -47,6 +48,9 @@ func tunnelModes(c TunnelConfig, cfg *ssh.ClientConfig, addr, op string) []stats
 		return nil
 	})
 
+	freshResult := c.summarize("tunnel", op, freshTimes, freshC)
+
+	c.pktReset()
 	batchTimes, batchC := sshFreshBench(c.Config, addr, cfg, func(conn *ssh.Client) error {
 		sess, err := conn.NewSession()
 		if err != nil {
@@ -58,7 +62,7 @@ func tunnelModes(c TunnelConfig, cfg *ssh.ClientConfig, addr, op string) []stats
 	})
 
 	return []stats.Result{
-		c.summarize("tunnel", op, freshTimes, freshC),
+		freshResult,
 		c.summarize("tunnel", op+"-batch", batchTimes, batchC),
 	}
 }


### PR DESCRIPTION
Fixes #24.

## Problem

Packet counts were only reported on the first benchmark mode per transport. All other modes showed 0. The first mode's value was actually the total for all modes combined.

## Fix

Pass `PktCounter` interface through `bench.Config`. Each mode calls `c.pktReset()` before execution, and `c.summarize()` auto-snapshots the counts. No more `pktWrap` wrapper in the runner.

## Before (HTTPS with regional latency)
```
https  fresh-conn  PKT_IN=242  PKT_OUT=234  (total for all 4 modes)
https  keep-alive  PKT_IN=0    PKT_OUT=0
https  batch-post  PKT_IN=0    PKT_OUT=0
https  multi-cmd   PKT_IN=0    PKT_OUT=0
```

## After
```
https  fresh-conn  PKT_IN=10  PKT_OUT=9
https  keep-alive  PKT_IN=10  PKT_OUT=9
https  batch-post  PKT_IN=10  PKT_OUT=9
https  multi-cmd   PKT_IN=10  PKT_OUT=8
```

## Testing

All tests pass with `-race`, 0 lint issues. Verified with `sudo` that each mode gets independent packet counts.