### PR TITLE
fix: decouple packet counter from netem latency (#26)

### DIFF
--- a/cmd/clibench/bench.go
+++ b/cmd/clibench/bench.go
@@ -233,7 +233,7 @@ func (b *BenchCmd) startServers(e *benchEnv, dev *device.Device) error {
 }
 
 func (b *BenchCmd) setupPktCounter(e *benchEnv) (*pktcount.Counter, func()) {
-	if b.Userspace || e.delay == 0 {
+	if b.Userspace {
 		return nil, func() {}
 	}
 


### PR DESCRIPTION
Fixes #26.

One-line fix: remove `e.delay == 0` guard from `setupPktCounter()`. Packet counting now works at any latency profile when running as root.

## Before
```
$ sudo ./bin/clibench bench --latency local --transport https --output table
https  fresh-conn  PKT_IN=0  PKT_OUT=0
```

## After
```
$ sudo ./bin/clibench bench --latency local --transport https --output table
https  fresh-conn  PKT_IN=9  PKT_OUT=9
https  keep-alive  PKT_IN=9  PKT_OUT=9
https  batch-post  PKT_IN=9  PKT_OUT=9
https  multi-cmd   PKT_IN=9  PKT_OUT=8
```

Without sudo, gracefully falls back with log message "packet counter unavailable".

## Testing

All tests pass with `-race`, 0 lint issues. Verified with `sudo` at local latency.