### PR TITLE
feat: add HTTP/3 proxy benchmark modes (#29)

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,8 @@ Output is JSON to stdout. Logs go to stderr.
 | `multi-cmd` | HTTPS | All commands in one GET (ASA `/cmd1/cmd2` syntax) |
 | `fresh-ssh` | Proxy | HTTPS→proxy→fresh SSH per request |
 | `pooled-ssh` | Proxy | HTTPS→proxy→pooled SSH connection |
+| `h3-fresh-ssh` | Proxy | HTTP/3→proxy→fresh SSH per request |
+| `h3-pooled-ssh` | Proxy | HTTP/3→proxy→pooled SSH connection |
 | `fresh-conn` | HTTP/3 | New QUIC + HTTP/3 connection per iteration |
 | `keep-alive` | HTTP/3 | Shared QUIC connection across all iterations |
 | `batch-post` | HTTP/3 | All commands in one POST body over shared connection |

--- a/cmd/clibench/bench.go
+++ b/cmd/clibench/bench.go
@@ -65,6 +65,8 @@ func (b *BenchCmd) has(t string) bool {
 //   ProxyPort+1      — proxy pooled-SSH mode (WAN delay)
 //   ProxyPort+2      — tunnel site HTTPS proxy (WAN delay)
 //   ProxyPort+3      — tunnel site HTTP/3 proxy (WAN delay)
+//   ProxyPort+4      — H3 proxy fresh-SSH mode (WAN delay)
+//   ProxyPort+5      — H3 proxy pooled-SSH mode (WAN delay)
 //   HeadendHTTPSPort — tunnel headend SSH (campus delay)
 //   HeadendH3Port    — tunnel headend SSH/H3 (campus delay)
 type benchEnv struct {
@@ -81,6 +83,8 @@ type benchEnv struct {
 	tunnelSiteHTTPSAddr string
 	tunnelSiteH3Port    int
 	tunnelSiteH3Addr    string
+	proxyH3FreshAddr    string
+	proxyH3PooledAddr   string
 	delay               time.Duration
 	campusDelay         time.Duration
 	rttMs               float64
@@ -105,6 +109,8 @@ func (b *BenchCmd) buildEnv() (*benchEnv, error) {
 		tunnelSiteHTTPSAddr: fmt.Sprintf("localhost:%d", b.ProxyPort+2),
 		tunnelSiteH3Port:    b.ProxyPort + 3,
 		tunnelSiteH3Addr:    fmt.Sprintf("localhost:%d", b.ProxyPort+3),
+		proxyH3FreshAddr:    fmt.Sprintf("localhost:%d", b.ProxyPort+4),
+		proxyH3PooledAddr:   fmt.Sprintf("localhost:%d", b.ProxyPort+5),
 		delay:               delay,
 		campusDelay:         1 * time.Millisecond,
 		rttMs:               float64(delay.Milliseconds()) * 2,
@@ -114,7 +120,7 @@ func (b *BenchCmd) buildEnv() (*benchEnv, error) {
 
 func (b *BenchCmd) setupLatency(e *benchEnv) error {
 	if !b.Userspace && e.delay > 0 {
-		wanPorts := []int{b.SSHPort, b.HTTPSPort, b.HTTP3Port, b.ProxyPort, b.ProxyPort + 1, e.tunnelSiteHTTPSPort, e.tunnelSiteH3Port}
+		wanPorts := []int{b.SSHPort, b.HTTPSPort, b.HTTP3Port, b.ProxyPort, b.ProxyPort + 1, b.ProxyPort + 4, b.ProxyPort + 5, e.tunnelSiteHTTPSPort, e.tunnelSiteH3Port}
 		campusPorts := []int{e.backendSSHPort, b.HeadendHTTPSPort, b.HeadendH3Port}
 		if err := netem.Setup(e.delay, e.campusDelay, wanPorts, campusPorts); err != nil {
 			return fmt.Errorf("tc netem setup (requires sudo): %w", err)
@@ -214,6 +220,12 @@ func (b *BenchCmd) startServers(e *benchEnv, dev *device.Device) error {
 	tunnelSiteH3 := proxy.New(e.tunnelSiteH3Addr, e.backendSSHAddr, b.User, b.Pass, true)
 	go tunnelSiteH3.ListenAndServeH3()
 
+	// H3 proxy (fresh + pooled SSH backends)
+	proxyH3Fresh := proxy.New(e.proxyH3FreshAddr, e.backendSSHAddr, b.User, b.Pass, false)
+	go proxyH3Fresh.ListenAndServeH3()
+	proxyH3Pooled := proxy.New(e.proxyH3PooledAddr, e.backendSSHAddr, b.User, b.Pass, true)
+	go proxyH3Pooled.ListenAndServeH3()
+
 	// Tunnel headend proxies
 	if err := startHeadend(e.headendHTTPSAddr, "https://"+e.tunnelSiteHTTPSAddr, "https", e.campusDelay); err != nil {
 		return err
@@ -238,6 +250,7 @@ func (b *BenchCmd) setupPktCounter(e *benchEnv) (*pktcount.Counter, func()) {
 	}
 
 	allPorts := []int{b.SSHPort, b.HTTPSPort, b.HTTP3Port, b.ProxyPort, b.ProxyPort + 1,
+		b.ProxyPort + 4, b.ProxyPort + 5,
 		e.backendSSHPort, e.tunnelSiteHTTPSPort, e.tunnelSiteH3Port,
 		b.HeadendHTTPSPort, b.HeadendH3Port}
 	pc, err := pktcount.New(allPorts)
@@ -293,7 +306,7 @@ func (b *BenchCmd) runBenchmarks(e *benchEnv, pc *pktcount.Counter) []stats.Resu
 		results = append(results, bench.HTTPS(c)...)
 	}
 	if b.has("proxy") {
-		results = append(results, bench.Proxy(bench.ProxyConfig{Config: cfg, FreshAddr: e.proxyAddr, PooledAddr: e.proxyPooledAddr})...)
+		results = append(results, bench.Proxy(bench.ProxyConfig{Config: cfg, FreshAddr: e.proxyAddr, PooledAddr: e.proxyPooledAddr, H3FreshAddr: e.proxyH3FreshAddr, H3PooledAddr: e.proxyH3PooledAddr})...)
 	}
 	if b.has("http3") {
 		c := cfg

--- a/internal/bench/bench.go
+++ b/internal/bench/bench.go
@@ -15,6 +15,8 @@ import (
 	"github.com/lykinsbd/clibench/internal/rtcount"
 	"github.com/lykinsbd/clibench/internal/stats"
 	"golang.org/x/crypto/ssh"
+
+	"github.com/quic-go/quic-go/http3"
 )
 
 var errDuration = stats.ErrDuration
@@ -486,8 +488,10 @@ func HTTPS(c Config) []stats.Result {
 // ProxyConfig extends Config with proxy-specific addresses.
 type ProxyConfig struct {
 	Config
-	FreshAddr  string // HTTPS proxy address (fresh SSH per request)
-	PooledAddr string // HTTPS proxy address (pooled SSH connection)
+	FreshAddr     string // HTTPS proxy address (fresh SSH per request)
+	PooledAddr    string // HTTPS proxy address (pooled SSH connection)
+	H3FreshAddr   string // HTTP/3 proxy address (fresh SSH per request)
+	H3PooledAddr  string // HTTP/3 proxy address (pooled SSH connection)
 }
 
 // Proxy runs all proxy benchmark modes and returns the results.
@@ -558,10 +562,66 @@ func Proxy(c ProxyConfig) []stats.Result {
 		return d
 	})
 
-	return []stats.Result{
+	results := []stats.Result{
 		freshResult,
 		c.summarize("proxy", "pooled-ssh", pooledTimes, pooledC),
 	}
+
+	// H3 proxy modes
+	if c.H3FreshAddr != "" {
+		h3TlsCfg := &tls.Config{InsecureSkipVerify: true, NextProtos: []string{"h3"}}
+
+		doProxyH3 := func(addr string) (time.Duration, int, int, int) {
+			start := time.Now()
+			var pc *rtcount.PacketConn
+			tr := &http3.Transport{TLSClientConfig: h3TlsCfg.Clone(), Dial: h3Dial(&pc)}
+			client := &http.Client{Transport: tr, Timeout: 30 * time.Second}
+			url := fmt.Sprintf("https://%s/admin/config", addr)
+			req, err := http.NewRequest("POST", url, strings.NewReader(payload))
+			if err != nil {
+				return errDuration, 0, 0, 0
+			}
+			req.SetBasicAuth(c.User, c.Pass)
+			resp, err := client.Do(req)
+			if err != nil {
+				log.Printf("proxy h3: %v", err)
+				tr.Close()
+				return errDuration, 0, 0, 0
+			}
+			_, _ = io.ReadAll(resp.Body)
+			resp.Body.Close()
+			tr.Close()
+			if resp.StatusCode != http.StatusOK {
+				log.Printf("proxy h3: HTTP %d", resp.StatusCode)
+				return errDuration, 0, 0, 0
+			}
+			var trips, reads, writes int
+			if pc != nil {
+				trips, reads, writes = pc.Trips(), pc.Reads(), pc.Writes()
+			}
+			return time.Since(start), trips, reads, writes
+		}
+
+		c.pktReset()
+		h3FreshC := newCounters(c.Iterations)
+		h3FreshTimes := stats.RunParallel(c.Iterations, c.Concurrency, func(idx int) time.Duration {
+			d, t, r, w := doProxyH3(c.H3FreshAddr)
+			h3FreshC.trips[idx], h3FreshC.reads[idx], h3FreshC.writes[idx] = t, r, w
+			return d
+		})
+		results = append(results, c.summarize("proxy", "h3-fresh-ssh", h3FreshTimes, h3FreshC))
+
+		c.pktReset()
+		h3PooledC := newCounters(c.Iterations)
+		h3PooledTimes := stats.RunParallel(c.Iterations, c.Concurrency, func(idx int) time.Duration {
+			d, t, r, w := doProxyH3(c.H3PooledAddr)
+			h3PooledC.trips[idx], h3PooledC.reads[idx], h3PooledC.writes[idx] = t, r, w
+			return d
+		})
+		results = append(results, c.summarize("proxy", "h3-pooled-ssh", h3PooledTimes, h3PooledC))
+	}
+
+	return results
 }
 
 func doHTTPExec(client *http.Client, addr, user, pass string) error {


### PR DESCRIPTION
Fixes #29.

## New modes

| Mode | Transport | Description |
|---|---|---|
| `h3-fresh-ssh` | Proxy | HTTP/3 → proxy → fresh SSH per request |
| `h3-pooled-ssh` | Proxy | HTTP/3 → proxy → pooled SSH connection |

## Sample output (local, 2 commands)

```
proxy  fresh-ssh      RT=3  RD_OPS=5   WR_OPS=3   7.3ms
proxy  pooled-ssh     RT=3  RD_OPS=5   WR_OPS=3   5.1ms
proxy  h3-fresh-ssh   RT=3  RD_OPS=12  WR_OPS=8   8.0ms
proxy  h3-pooled-ssh  RT=3  RD_OPS=11  WR_OPS=9   5.0ms
```

## Implementation

- `ProxyConfig` gains `H3FreshAddr`/`H3PooledAddr` fields
- Two new H3 proxy servers started on `ProxyPort+4`/`ProxyPort+5`
- `doProxyH3` uses `http3.Transport` with `rtcount.PacketConn` for counting
- H3 proxy ports added to netem WAN list and pktcount port list

## Testing

All tests pass with `-race`, 0 lint issues.