### PR TITLE
feat: --resource flag for CPU/memory benchmarking (#37)

### DIFF
--- a/cmd/clibench/bench.go
+++ b/cmd/clibench/bench.go
@@ -31,6 +31,7 @@ type BenchCmd struct {
 	Commands    int      `help:"Commands per iteration." default:"1"`
 	Latency     string   `help:"Latency profile (${enum})." enum:"local,campus,regional,continental,intercontinental,transpacific" default:"local" short:"l"`
 	Userspace   bool     `help:"Use userspace latency injection (no root required)."`
+	Resource    bool     `help:"Capture CPU and memory usage per iteration."`
 	Output      string   `help:"Output format (${enum})." enum:"json,table,csv" default:"json" short:"o"`
 
 	SSHPort          int `help:"SSH listen port." default:"2222" group:"server"`
@@ -288,6 +289,7 @@ func (b *BenchCmd) runBenchmarks(e *benchEnv, pc *pktcount.Counter) []stats.Resu
 		Profile:     b.Latency,
 		RTTms:       e.rttMs,
 		Hostname:    b.Hostname,
+		Resource:    b.Resource,
 	}
 	if pc != nil {
 		cfg.PktCounter = pc

--- a/cmd/clibench/format.go
+++ b/cmd/clibench/format.go
@@ -11,11 +11,12 @@ import (
 
 func writeTable(w io.Writer, results []stats.Result) error {
 	tw := tabwriter.NewWriter(w, 0, 4, 2, ' ', 0)
-	fmt.Fprintln(tw, "TRANSPORT\tOPERATION\tCMDS\tITER\tERR\tRT\tRD_OPS\tWR_OPS\tPKT_IN\tPKT_OUT\tAVG(ms)\tMIN(ms)\tP50(ms)\tP95(ms)\tMAX(ms)\tSTDDEV(ms)")
+	fmt.Fprintln(tw, "TRANSPORT\tOPERATION\tCMDS\tITER\tERR\tRT\tRD_OPS\tWR_OPS\tPKT_IN\tPKT_OUT\tCPU_US\tALLOC_B\tALLOCS\tAVG(ms)\tMIN(ms)\tP50(ms)\tP95(ms)\tMAX(ms)\tSTDDEV(ms)")
 	for _, r := range results {
-		fmt.Fprintf(tw, "%s\t%s\t%d\t%d\t%d\t%d\t%d\t%d\t%d\t%d\t%.2f\t%.2f\t%.2f\t%.2f\t%.2f\t%.2f\n",
+		fmt.Fprintf(tw, "%s\t%s\t%d\t%d\t%d\t%d\t%d\t%d\t%d\t%d\t%d\t%d\t%d\t%.2f\t%.2f\t%.2f\t%.2f\t%.2f\t%.2f\n",
 			r.Transport, r.Operation, r.Commands, r.Iterations, r.Errors,
 			r.RoundTrips, r.ReadOps, r.WriteOps, r.PacketsIn, r.PacketsOut,
+			r.CPUUs, r.AllocBytes, r.Allocs,
 			r.AvgMs, r.MinMs, r.P50Ms, r.P95Ms, r.MaxMs, r.StddevMs)
 	}
 	return tw.Flush()
@@ -28,6 +29,7 @@ func writeCSV(w io.Writer, results []stats.Result) error {
 		"transport", "operation", "commands", "iterations", "errors",
 		"concurrency", "latency_profile", "simulated_rtt_ms",
 		"round_trips", "read_ops", "write_ops", "packets_in", "packets_out",
+		"cpu_us", "alloc_bytes", "allocs",
 		"avg_ms", "min_ms", "p50_ms", "p95_ms", "max_ms", "stddev_ms",
 	})
 	for _, r := range results {
@@ -39,6 +41,8 @@ func writeCSV(w io.Writer, results []stats.Result) error {
 			fmt.Sprintf("%d", r.RoundTrips),
 			fmt.Sprintf("%d", r.ReadOps), fmt.Sprintf("%d", r.WriteOps),
 			fmt.Sprintf("%d", r.PacketsIn), fmt.Sprintf("%d", r.PacketsOut),
+			fmt.Sprintf("%d", r.CPUUs), fmt.Sprintf("%d", r.AllocBytes),
+			fmt.Sprintf("%d", r.Allocs),
 			fmt.Sprintf("%.3f", r.AvgMs), fmt.Sprintf("%.3f", r.MinMs),
 			fmt.Sprintf("%.3f", r.P50Ms), fmt.Sprintf("%.3f", r.P95Ms),
 			fmt.Sprintf("%.3f", r.MaxMs), fmt.Sprintf("%.3f", r.StddevMs),

--- a/internal/bench/bench.go
+++ b/internal/bench/bench.go
@@ -12,6 +12,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/lykinsbd/clibench/internal/resource"
 	"github.com/lykinsbd/clibench/internal/rtcount"
 	"github.com/lykinsbd/clibench/internal/stats"
 	"golang.org/x/crypto/ssh"
@@ -49,6 +50,7 @@ type Config struct {
 	RTTms       float64    // simulated round-trip time in milliseconds
 	Hostname    string     // device hostname for PTY prompt detection
 	PktCounter  PktCounter // optional packet counter (nil when unavailable)
+	Resource    bool       // capture CPU and memory per iteration
 }
 
 // pktReset resets the packet counter (no-op if nil).
@@ -104,10 +106,47 @@ func sshDialCounted(addr string, cfg *ssh.ClientConfig) (*ssh.Client, *rtcount.C
 // counters collects per-iteration stats from parallel slices.
 type counters struct {
 	trips, reads, writes []int
+	cpuUs                []int64
+	allocBytes           []uint64
+	allocs               []uint64
 }
 
-func newCounters(n int) counters {
-	return counters{make([]int, n), make([]int, n), make([]int, n)}
+func newCountersWithResource(n int) counters {
+	return counters{
+		trips: make([]int, n), reads: make([]int, n), writes: make([]int, n),
+		cpuUs: make([]int64, n), allocBytes: make([]uint64, n), allocs: make([]uint64, n),
+	}
+}
+
+// makeCounters creates counters with resource slices if Resource is enabled.
+func (c Config) makeCounters() counters {
+	if c.Resource {
+		return newCountersWithResource(c.Iterations)
+	}
+	return counters{make([]int, c.Iterations), make([]int, c.Iterations), make([]int, c.Iterations), nil, nil, nil}
+}
+
+func (cnt counters) recordResource(idx int, d resource.Delta) {
+	if cnt.cpuUs != nil {
+		cnt.cpuUs[idx] = d.CPUUs
+		cnt.allocBytes[idx] = d.Bytes
+		cnt.allocs[idx] = d.Allocs
+	}
+}
+
+// resourceSnap returns a snapshot if resource tracking is enabled, zero otherwise.
+func (c Config) resourceSnap() resource.Snapshot {
+	if c.Resource {
+		return resource.Now()
+	}
+	return resource.Snapshot{}
+}
+
+// resourceRecord records the delta if resource tracking is enabled.
+func (c Config) resourceRecord(cnt counters, idx int, snap resource.Snapshot) {
+	if c.Resource {
+		cnt.recordResource(idx, resource.Since(snap))
+	}
 }
 
 func (c counters) recordConn(idx int, cc *rtcount.Conn) {
@@ -143,15 +182,19 @@ func (c counters) recordPacketDelta(idx int, pc *rtcount.PacketConn, bt, br, bw 
 }
 
 func (c counters) iter() stats.IterCounts {
-	return stats.IterCounts{Trips: c.trips, Reads: c.reads, Writes: c.writes}
+	return stats.IterCounts{
+		Trips: c.trips, Reads: c.reads, Writes: c.writes,
+		CPUUs: c.cpuUs, AllocBytes: c.allocBytes, Allocs: c.allocs,
+	}
 }
 
 // sshFreshBench runs a fresh-connection SSH benchmark where each iteration
 // dials, executes commands, and closes. Used by SSH fresh-conn, batch-exec,
 // and tunnel modes.
 func sshFreshBench(c Config, addr string, cfg *ssh.ClientConfig, execFn func(*ssh.Client) error) ([]time.Duration, counters) {
-	cnt := newCounters(c.Iterations)
+	cnt := c.makeCounters()
 	times := stats.RunParallel(c.Iterations, c.Concurrency, func(idx int) time.Duration {
+		snap := c.resourceSnap()
 		start := time.Now()
 		conn, cc, err := sshDialCounted(addr, cfg)
 		if err != nil {
@@ -162,6 +205,7 @@ func sshFreshBench(c Config, addr string, cfg *ssh.ClientConfig, execFn func(*ss
 			return errDuration
 		}
 		cnt.recordConn(idx, cc)
+		c.resourceRecord(cnt, idx, snap)
 		return time.Since(start)
 	})
 	return times, cnt
@@ -201,8 +245,9 @@ func SSH(c Config) []stats.Result {
 			_, _ = sess.Output("show version")
 			sess.Close()
 		}
-		reuseC = newCounters(c.Iterations)
+		reuseC = c.makeCounters()
 		reuseTimes = stats.RunParallel(c.Iterations, c.Concurrency, func(idx int) time.Duration {
+			snap := c.resourceSnap()
 			// Delta counting on shared conn is only valid at concurrency=1.
 			var bt, br, bw int
 			if c.Concurrency == 1 {
@@ -225,6 +270,7 @@ func SSH(c Config) []stats.Result {
 			if c.Concurrency == 1 {
 				reuseC.recordConnDelta(idx, sharedCC, bt, br, bw)
 			}
+			c.resourceRecord(reuseC, idx, snap)
 			return time.Since(start)
 		})
 		sharedConn.Close()
@@ -272,8 +318,9 @@ func SSH(c Config) []stats.Result {
 			_ = ptyExecCmds(sess, prompt, 1)
 			sess.Close()
 		}
-		ptyReuseC := newCounters(c.Iterations)
+		ptyReuseC := c.makeCounters()
 		ptyReuseTimes := stats.RunParallel(c.Iterations, c.Concurrency, func(idx int) time.Duration {
+			snap := c.resourceSnap()
 			var bt, br, bw int
 			if c.Concurrency == 1 {
 				bt, br, bw = ptyCC.Trips(), ptyCC.Reads(), ptyCC.Writes()
@@ -291,6 +338,7 @@ func SSH(c Config) []stats.Result {
 			if c.Concurrency == 1 {
 				ptyReuseC.recordConnDelta(idx, ptyCC, bt, br, bw)
 			}
+			c.resourceRecord(ptyReuseC, idx, snap)
 			return time.Since(start)
 		})
 		ptyConn.Close()
@@ -336,8 +384,9 @@ func HTTPS(c Config) []stats.Result {
 
 	c.pktReset()
 	// Mode 1: fresh connection per iteration
-	freshC := newCounters(c.Iterations)
+	freshC := c.makeCounters()
 	freshTimes := stats.RunParallel(c.Iterations, c.Concurrency, func(idx int) time.Duration {
+		snap := c.resourceSnap()
 		start := time.Now()
 		var conns []*rtcount.Conn
 		tr := &http.Transport{
@@ -366,6 +415,7 @@ func HTTPS(c Config) []stats.Result {
 			}
 		}
 		freshC.recordConns(idx, conns)
+		c.resourceRecord(freshC, idx, snap)
 		return time.Since(start)
 	})
 
@@ -375,8 +425,9 @@ func HTTPS(c Config) []stats.Result {
 	keepClient := &http.Client{Transport: keepTr.Transport, Timeout: 30 * time.Second}
 	_ = doHTTPExec(keepClient, c.Addr, c.User, c.Pass)
 
-	keepC := newCounters(c.Iterations)
+	keepC := c.makeCounters()
 	reuseTimes := stats.RunParallel(c.Iterations, c.Concurrency, func(idx int) time.Duration {
+		snap := c.resourceSnap()
 		var bt, br, bw int
 		if c.Concurrency == 1 && keepTr.cc != nil {
 			bt, br, bw = keepTr.cc.Trips(), keepTr.cc.Reads(), keepTr.cc.Writes()
@@ -391,6 +442,7 @@ func HTTPS(c Config) []stats.Result {
 		if c.Concurrency == 1 && keepTr.cc != nil {
 			keepC.recordConnDelta(idx, keepTr.cc, bt, br, bw)
 		}
+		c.resourceRecord(keepC, idx, snap)
 		return time.Since(start)
 	})
 
@@ -401,8 +453,9 @@ func HTTPS(c Config) []stats.Result {
 	batchClient := &http.Client{Transport: batchTr.Transport, Timeout: 30 * time.Second}
 	_ = doHTTPExec(batchClient, c.Addr, c.User, c.Pass)
 
-	batchC := newCounters(c.Iterations)
+	batchC := c.makeCounters()
 	batchTimes := stats.RunParallel(c.Iterations, c.Concurrency, func(idx int) time.Duration {
+		snap := c.resourceSnap()
 		var bt, br, bw int
 		if c.Concurrency == 1 && batchTr.cc != nil {
 			bt, br, bw = batchTr.cc.Trips(), batchTr.cc.Reads(), batchTr.cc.Writes()
@@ -428,6 +481,7 @@ func HTTPS(c Config) []stats.Result {
 		if c.Concurrency == 1 && batchTr.cc != nil {
 			batchC.recordConnDelta(idx, batchTr.cc, bt, br, bw)
 		}
+		c.resourceRecord(batchC, idx, snap)
 		return time.Since(start)
 	})
 
@@ -450,8 +504,9 @@ func HTTPS(c Config) []stats.Result {
 		multiClient := &http.Client{Transport: multiTr.Transport, Timeout: 30 * time.Second}
 		_ = doHTTPExec(multiClient, c.Addr, c.User, c.Pass)
 
-		multiC := newCounters(c.Iterations)
+		multiC := c.makeCounters()
 		multiTimes := stats.RunParallel(c.Iterations, c.Concurrency, func(idx int) time.Duration {
+		snap := c.resourceSnap()
 			var bt, br, bw int
 			if c.Concurrency == 1 && multiTr.cc != nil {
 				bt, br, bw = multiTr.cc.Trips(), multiTr.cc.Reads(), multiTr.cc.Writes()
@@ -477,6 +532,7 @@ func HTTPS(c Config) []stats.Result {
 			if c.Concurrency == 1 && multiTr.cc != nil {
 				multiC.recordConnDelta(idx, multiTr.cc, bt, br, bw)
 			}
+			c.resourceRecord(multiC, idx, snap)
 			return time.Since(start)
 		})
 		results = append(results, c.summarize("https", "multi-cmd", multiTimes, multiC))
@@ -546,19 +602,23 @@ func Proxy(c ProxyConfig) []stats.Result {
 	}
 
 	c.pktReset()
-	freshC := newCounters(c.Iterations)
+	freshC := c.makeCounters()
 	freshTimes := stats.RunParallel(c.Iterations, c.Concurrency, func(idx int) time.Duration {
+		snap := c.resourceSnap()
 		d, t, r, w := doProxy(c.FreshAddr)
 		freshC.trips[idx], freshC.reads[idx], freshC.writes[idx] = t, r, w
+		c.resourceRecord(freshC, idx, snap)
 		return d
 	})
 	freshResult := c.summarize("proxy", "fresh-ssh", freshTimes, freshC)
 
 	c.pktReset()
-	pooledC := newCounters(c.Iterations)
+	pooledC := c.makeCounters()
 	pooledTimes := stats.RunParallel(c.Iterations, c.Concurrency, func(idx int) time.Duration {
+		snap := c.resourceSnap()
 		d, t, r, w := doProxy(c.PooledAddr)
 		pooledC.trips[idx], pooledC.reads[idx], pooledC.writes[idx] = t, r, w
+		c.resourceRecord(pooledC, idx, snap)
 		return d
 	})
 
@@ -603,19 +663,23 @@ func Proxy(c ProxyConfig) []stats.Result {
 		}
 
 		c.pktReset()
-		h3FreshC := newCounters(c.Iterations)
+		h3FreshC := c.makeCounters()
 		h3FreshTimes := stats.RunParallel(c.Iterations, c.Concurrency, func(idx int) time.Duration {
+			snap := c.resourceSnap()
 			d, t, r, w := doProxyH3(c.H3FreshAddr)
 			h3FreshC.trips[idx], h3FreshC.reads[idx], h3FreshC.writes[idx] = t, r, w
+			c.resourceRecord(h3FreshC, idx, snap)
 			return d
 		})
 		results = append(results, c.summarize("proxy", "h3-fresh-ssh", h3FreshTimes, h3FreshC))
 
 		c.pktReset()
-		h3PooledC := newCounters(c.Iterations)
+		h3PooledC := c.makeCounters()
 		h3PooledTimes := stats.RunParallel(c.Iterations, c.Concurrency, func(idx int) time.Duration {
+			snap := c.resourceSnap()
 			d, t, r, w := doProxyH3(c.H3PooledAddr)
 			h3PooledC.trips[idx], h3PooledC.reads[idx], h3PooledC.writes[idx] = t, r, w
+			c.resourceRecord(h3PooledC, idx, snap)
 			return d
 		})
 		results = append(results, c.summarize("proxy", "h3-pooled-ssh", h3PooledTimes, h3PooledC))
@@ -644,8 +708,9 @@ func Proxy(c ProxyConfig) []stats.Result {
 	// Warmup to establish connection
 	_ = doProxyPost(keepClient, c.PooledAddr, c.User, c.Pass, payload)
 
-	keepC := newCounters(c.Iterations)
+	keepC := c.makeCounters()
 	keepTimes := stats.RunParallel(c.Iterations, c.Concurrency, func(idx int) time.Duration {
+		snap := c.resourceSnap()
 		var bt, br, bw int
 		if c.Concurrency == 1 && keepCC != nil {
 			bt, br, bw = keepCC.Trips(), keepCC.Reads(), keepCC.Writes()
@@ -658,6 +723,7 @@ func Proxy(c ProxyConfig) []stats.Result {
 		if c.Concurrency == 1 && keepCC != nil {
 			keepC.recordConnDelta(idx, keepCC, bt, br, bw)
 		}
+		c.resourceRecord(keepC, idx, snap)
 		return time.Since(start)
 	})
 	results = append(results, c.summarize("proxy", "keep-alive", keepTimes, keepC))
@@ -673,8 +739,9 @@ func Proxy(c ProxyConfig) []stats.Result {
 		h3KeepClient := &http.Client{Transport: h3KeepTr, Timeout: 30 * time.Second}
 		_ = doProxyPost(h3KeepClient, c.H3PooledAddr, c.User, c.Pass, payload)
 
-		h3KeepC := newCounters(c.Iterations)
+		h3KeepC := c.makeCounters()
 		h3KeepTimes := stats.RunParallel(c.Iterations, c.Concurrency, func(idx int) time.Duration {
+			snap := c.resourceSnap()
 			var bt, br, bw int
 			if c.Concurrency == 1 && h3KeepCC != nil {
 				bt, br, bw = h3KeepCC.Trips(), h3KeepCC.Reads(), h3KeepCC.Writes()
@@ -687,6 +754,7 @@ func Proxy(c ProxyConfig) []stats.Result {
 			if c.Concurrency == 1 && h3KeepCC != nil {
 				h3KeepC.recordPacketDelta(idx, h3KeepCC, bt, br, bw)
 			}
+			c.resourceRecord(h3KeepC, idx, snap)
 			return time.Since(start)
 		})
 		h3KeepTr.Close()

--- a/internal/bench/http3.go
+++ b/internal/bench/http3.go
@@ -44,8 +44,9 @@ func HTTP3(c Config) []stats.Result {
 
 	c.pktReset()
 	// Mode 1: fresh connection per iteration
-	freshC := newCounters(c.Iterations)
+	freshC := c.makeCounters()
 	freshTimes := stats.RunParallel(c.Iterations, c.Concurrency, func(idx int) time.Duration {
+		snap := c.resourceSnap()
 		start := time.Now()
 		var cc *rtcount.PacketConn
 		tr := &http3.Transport{TLSClientConfig: tlsCfg.Clone(), Dial: h3Dial(&cc)}
@@ -61,6 +62,7 @@ func HTTP3(c Config) []stats.Result {
 			freshC.recordPacket(idx, cc)
 		}
 		tr.Close()
+		c.resourceRecord(freshC, idx, snap)
 		return time.Since(start)
 	})
 
@@ -71,8 +73,9 @@ func HTTP3(c Config) []stats.Result {
 	keepClient := &http.Client{Transport: keepTr, Timeout: 30 * time.Second}
 	_ = doHTTPExec(keepClient, c.Addr, c.User, c.Pass)
 
-	keepC := newCounters(c.Iterations)
+	keepC := c.makeCounters()
 	keepTimes := stats.RunParallel(c.Iterations, c.Concurrency, func(idx int) time.Duration {
+		snap := c.resourceSnap()
 		var bt, br, bw int
 		if c.Concurrency == 1 && keepCC != nil {
 			bt, br, bw = keepCC.Trips(), keepCC.Reads(), keepCC.Writes()
@@ -87,6 +90,7 @@ func HTTP3(c Config) []stats.Result {
 		if c.Concurrency == 1 && keepCC != nil {
 			keepC.recordPacketDelta(idx, keepCC, bt, br, bw)
 		}
+		c.resourceRecord(keepC, idx, snap)
 		return time.Since(start)
 	})
 	keepTr.Close()
@@ -99,8 +103,9 @@ func HTTP3(c Config) []stats.Result {
 	batchClient := &http.Client{Transport: batchTr, Timeout: 30 * time.Second}
 	_ = doHTTPExec(batchClient, c.Addr, c.User, c.Pass)
 
-	batchC := newCounters(c.Iterations)
+	batchC := c.makeCounters()
 	batchTimes := stats.RunParallel(c.Iterations, c.Concurrency, func(idx int) time.Duration {
+		snap := c.resourceSnap()
 		var bt, br, bw int
 		if c.Concurrency == 1 && batchCC != nil {
 			bt, br, bw = batchCC.Trips(), batchCC.Reads(), batchCC.Writes()
@@ -126,6 +131,7 @@ func HTTP3(c Config) []stats.Result {
 		if c.Concurrency == 1 && batchCC != nil {
 			batchC.recordPacketDelta(idx, batchCC, bt, br, bw)
 		}
+		c.resourceRecord(batchC, idx, snap)
 		return time.Since(start)
 	})
 	batchTr.Close()
@@ -153,8 +159,9 @@ func HTTP3(c Config) []stats.Result {
 	warmTr.Close()
 	time.Sleep(50 * time.Millisecond)
 
-	zeroC := newCounters(c.Iterations)
+	zeroC := c.makeCounters()
 	zeroTimes := stats.RunParallel(c.Iterations, c.Concurrency, func(idx int) time.Duration {
+		snap := c.resourceSnap()
 		start := time.Now()
 		var cc *rtcount.PacketConn
 		tr := &http3.Transport{
@@ -174,6 +181,7 @@ func HTTP3(c Config) []stats.Result {
 			zeroC.recordPacket(idx, cc)
 		}
 		tr.Close()
+		c.resourceRecord(zeroC, idx, snap)
 		return time.Since(start)
 	})
 	results = append(results, c.summarize("http3", "0rtt-resumption", zeroTimes, zeroC))

--- a/internal/resource/resource.go
+++ b/internal/resource/resource.go
@@ -1,0 +1,83 @@
+// Package resource captures per-iteration CPU and memory usage.
+package resource
+
+import (
+	"os"
+	"runtime"
+)
+
+// Snapshot holds resource usage at a point in time.
+type Snapshot struct {
+	CPUNs  int64
+	Allocs uint64
+	Bytes  uint64
+}
+
+// Now captures current resource usage.
+func Now() Snapshot {
+	var m runtime.MemStats
+	runtime.ReadMemStats(&m)
+	return Snapshot{
+		CPUNs:  cpuNanos(),
+		Allocs: m.Mallocs,
+		Bytes:  m.TotalAlloc,
+	}
+}
+
+// Delta holds the resource difference between two snapshots.
+type Delta struct {
+	CPUUs  int64  // microseconds of CPU (user+system)
+	Allocs uint64 // heap allocation count
+	Bytes  uint64 // heap bytes allocated
+}
+
+// Since returns the resource delta since s.
+func Since(s Snapshot) Delta {
+	now := Now()
+	return Delta{
+		CPUUs:  (now.CPUNs - s.CPUNs) / 1000,
+		Allocs: now.Allocs - s.Allocs,
+		Bytes:  now.Bytes - s.Bytes,
+	}
+}
+
+// cpuNanos reads user+system CPU time from /proc/self/stat.
+// Returns 0 on non-Linux or on error.
+func cpuNanos() int64 {
+	data, err := os.ReadFile("/proc/self/stat")
+	if err != nil {
+		return 0
+	}
+	// Find closing paren of comm field.
+	i := len(data) - 1
+	for i >= 0 && data[i] != ')' {
+		i--
+	}
+	if i < 0 {
+		return 0
+	}
+	// After ") X " (state), fields are space-separated.
+	// utime is field 14 (0-indexed from start), which is field index 11
+	// after the closing paren (fields after ") " start at index 0 = state).
+	fields := 0
+	var utime, stime int64
+	for j := i + 2; j < len(data); j++ {
+		if data[j] == ' ' {
+			fields++
+		} else if fields == 11 {
+			for j < len(data) && data[j] >= '0' && data[j] <= '9' {
+				utime = utime*10 + int64(data[j]-'0')
+				j++
+			}
+		} else if fields == 12 {
+			for j < len(data) && data[j] >= '0' && data[j] <= '9' {
+				stime = stime*10 + int64(data[j]-'0')
+				j++
+			}
+			break
+		}
+	}
+	// Clock ticks to nanoseconds. SC_CLK_TCK = 100 on Linux (10ms/tick).
+	const tickNs = 10_000_000 // 1e9 / 100
+	return (utime + stime) * tickNs
+}

--- a/internal/stats/stats.go
+++ b/internal/stats/stats.go
@@ -28,6 +28,9 @@ type Result struct {
 	WriteOps    int     `json:"write_ops,omitempty"`
 	PacketsIn   int     `json:"packets_in,omitempty"`
 	PacketsOut  int     `json:"packets_out,omitempty"`
+	CPUUs       int64   `json:"cpu_us,omitempty"`
+	AllocBytes  uint64  `json:"alloc_bytes,omitempty"`
+	Allocs      uint64  `json:"allocs,omitempty"`
 	AvgMs       float64 `json:"avg_ms"`
 	MinMs       float64 `json:"min_ms"`
 	MaxMs       float64 `json:"max_ms"`
@@ -38,9 +41,12 @@ type Result struct {
 
 // IterCounts holds per-iteration counters collected alongside durations.
 type IterCounts struct {
-	Trips  []int
-	Reads  []int
-	Writes []int
+	Trips      []int
+	Reads      []int
+	Writes     []int
+	CPUUs      []int64
+	AllocBytes []uint64
+	Allocs     []uint64
 }
 
 // SummarizeConfig holds the parameters for Summarize.
@@ -117,6 +123,9 @@ func Summarize(cfg SummarizeConfig) Result {
 		RoundTrips:  medianInts(ic.Trips),
 		ReadOps:     medianInts(ic.Reads),
 		WriteOps:    medianInts(ic.Writes),
+		CPUUs:       medianInt64s(ic.CPUUs),
+		AllocBytes:  medianUint64s(ic.AllocBytes),
+		Allocs:      medianUint64s(ic.Allocs),
 		AvgMs:       avg,
 		MinMs:       valid[0],
 		MaxMs:       valid[n-1],
@@ -134,6 +143,34 @@ func medianInts(s []int) int {
 	c := make([]int, len(s))
 	copy(c, s)
 	sort.Ints(c)
+	n := len(c)
+	if n%2 == 1 {
+		return c[n/2]
+	}
+	return (c[n/2-1] + c[n/2]) / 2
+}
+
+func medianInt64s(s []int64) int64 {
+	if len(s) == 0 {
+		return 0
+	}
+	c := make([]int64, len(s))
+	copy(c, s)
+	sort.Slice(c, func(i, j int) bool { return c[i] < c[j] })
+	n := len(c)
+	if n%2 == 1 {
+		return c[n/2]
+	}
+	return (c[n/2-1] + c[n/2]) / 2
+}
+
+func medianUint64s(s []uint64) uint64 {
+	if len(s) == 0 {
+		return 0
+	}
+	c := make([]uint64, len(s))
+	copy(c, s)
+	sort.Slice(c, func(i, j int) bool { return c[i] < c[j] })
 	n := len(c)
 	if n%2 == 1 {
 		return c[n/2]


### PR DESCRIPTION
Fixes #37.

## What

Adds `--resource` flag that captures per-iteration CPU and memory usage alongside latency measurements.

## Metrics captured

| Field | Source | Description |
|---|---|---|
| `cpu_us` | `/proc/self/stat` | User+system CPU microseconds (10ms granularity) |
| `alloc_bytes` | `runtime.ReadMemStats` | Heap bytes allocated per iteration |
| `allocs` | `runtime.ReadMemStats` | Heap allocation count per iteration |

## Design

- `Config.Resource bool` gates all measurement
- `resourceSnap()` / `resourceRecord()` are no-ops when disabled — zero overhead on normal runs
- `ReadMemStats` STW (~100μs) only occurs when `--resource` is set
- Median values reported (same as round_trips, read_ops, etc.)
- JSON fields use `omitempty` — absent when `--resource` not set

## Sample output (local, 2 commands)

```
TRANSPORT  OPERATION    ALLOC_B  ALLOCS
ssh        fresh-conn   132824   912
ssh        reuse-conn    27224   272
https      fresh-conn   304224   2128
https      keep-alive    23752   216
https      batch-post    17440   124
```

Key insight: HTTPS fresh-conn allocates more than SSH (TLS is allocation-heavy), but keep-alive/batch amortize this to far less than SSH per-operation.

## CPU granularity note

`/proc/self/stat` has 10ms (jiffy) resolution. At regional+ latencies, individual iterations take 30-400ms of wall time but <1ms of actual CPU, so `cpu_us` reads 0. The metric becomes useful at high iteration counts or when comparing aggregate CPU across a full benchmark run. Allocation counts are the more immediately useful metric for per-iteration comparison.

## Testing

All 14 test packages pass with `-race`, 0 lint issues.